### PR TITLE
Convert hex keys to plain numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,10 +296,11 @@ programs:
                 - name: string
             - name: operation
               decoders:
+                - name: uint64
                 - name: static_map
                   static_map:
-                    0x1: read
-                    0x2: write
+                    1: read
+                    2: write
             - name: bucket
               decoders:
                 - name: uint64
@@ -316,10 +317,11 @@ programs:
                 - name: string
             - name: operation
               decoders:
+                - name: uint64
                 - name: static_map
                   static_map:
-                    0x1: read
-                    0x2: write
+                    1: read
+                    2: write
             - name: bucket
               decoders:
                 - name: uint64

--- a/examples/bio.yaml
+++ b/examples/bio.yaml
@@ -15,10 +15,11 @@ programs:
                 - name: string
             - name: operation
               decoders:
+                - name: uint64
                 - name: static_map
                   static_map:
-                    0x1: read
-                    0x2: write
+                    1: read
+                    2: write
             - name: bucket
               decoders:
                 - name: uint64
@@ -35,10 +36,11 @@ programs:
                 - name: string
             - name: operation
               decoders:
+                - name: uint64
                 - name: static_map
                   static_map:
-                    0x1: read
-                    0x2: write
+                    1: read
+                    2: write
             - name: bucket
               decoders:
                 - name: uint64

--- a/examples/dcstat.yaml
+++ b/examples/dcstat.yaml
@@ -11,11 +11,12 @@ programs:
           labels:
             - name: op
               decoders:
+                - name: uint
                 - name: static_map
                   static_map:
-                    0x1: refs
-                    0x2: slow
-                    0x3: miss
+                    1: refs
+                    2: slow
+                    3: miss
             - name: command
               decoders:
                 - name: string


### PR DESCRIPTION
This makes it easier to copy-paste jobs into configuration
management tools that transform yaml keys like `0x1` into numbers.