### PR TITLE
Fixing cases for fields that contains space

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ go:
   - 1.x
   - master
 
+go_import_path: github.com/cloudflare/ebpf_exporter
+
 before_install:
   # Install bcc
   - sudo apt-get update && sudo apt-get install -y lsb-release

--- a/README.md
+++ b/README.md
@@ -564,8 +564,8 @@ An example to report metrics only for `systemd-journal` and `syslog-ng`:
     - name: string
     - name: regexp
       regexps:
-        - ^systemd-journal$
-        - ^syslog-ng$
+        - systemd-journal\b
+        - syslog-ng\b
 ```
 
 #### `static_map`

--- a/decoder/ksym_test.go
+++ b/decoder/ksym_test.go
@@ -1,0 +1,25 @@
+package decoder
+
+import (
+	"testing"
+
+	"github.com/cloudflare/ebpf_exporter/config"
+)
+
+func TestKsymDecode(t *testing.T) {
+	for _, tc := range []struct {
+		in string
+		v  string
+		l  int
+	}{
+		{`0x2 testing`, "hello", 3},
+	} {
+		s := &KSym{
+			cache: map[string]string{"1": "hello"},
+		}
+		out, lout, _ := s.Decode(tc.in, config.Decoder{})
+		if out != tc.v || lout != tc.l {
+			t.Errorf("Expected %s(%d), got %s(%d)", tc.v, tc.l, out, lout)
+		}
+	}
+}

--- a/decoder/regexp_test.go
+++ b/decoder/regexp_test.go
@@ -1,0 +1,28 @@
+package decoder
+
+import (
+	"testing"
+
+	"github.com/cloudflare/ebpf_exporter/config"
+)
+
+func TestRegexpDecode(t *testing.T) {
+	for _, tc := range []struct {
+		in     string
+		regexp string
+		v      string
+		l      int
+	}{
+		{`journald testing`, `systemd-journald\b`, "", 0},
+		{`journald testing`, `journald\b`, "journald", 8},
+		{`hello testing`, `hel\w{2}\b`, "hello", 5},
+	} {
+		s := &Regexp{}
+		out, lout, _ := s.Decode(tc.in, config.Decoder{
+			Regexps: []string{tc.regexp},
+		})
+		if out != tc.v || lout != tc.l {
+			t.Errorf("Expected %s(%d), got %s(%d)", tc.v, tc.l, out, lout)
+		}
+	}
+}

--- a/decoder/static_map.go
+++ b/decoder/static_map.go
@@ -10,17 +10,22 @@ import (
 type StaticMap struct{}
 
 // Decode maps values according to a static map
-func (s *StaticMap) Decode(in string, conf config.Decoder) (string, error) {
+func (s *StaticMap) Decode(in string, conf config.Decoder) (string, int, error) {
 	// TODO: err?
 	if conf.StaticMap == nil {
-		return "empty mapping", nil
+		return "empty mapping", 0, nil
 	}
 
-	value, ok := conf.StaticMap[in]
+	var val string
+	if _, err := fmt.Sscan(in, &val); err != nil {
+		return "", 0, err
+	}
+
+	res, ok := conf.StaticMap[val]
 	if !ok {
 		// TODO: err?
-		return fmt.Sprintf("unknown:%s", in), nil
+		res = fmt.Sprintf("unknown:%s", val)
 	}
 
-	return value, nil
+	return res, len(val), nil
 }

--- a/decoder/static_map_test.go
+++ b/decoder/static_map_test.go
@@ -1,0 +1,28 @@
+package decoder
+
+import (
+	"testing"
+
+	"github.com/cloudflare/ebpf_exporter/config"
+)
+
+func TestStaticMapDecode(t *testing.T) {
+	for _, tc := range []struct {
+		in string
+		v  string
+		l  int
+	}{
+		{`0x2 testing`, "slow", 3},
+	} {
+		s := &StaticMap{}
+		out, lout, err := s.Decode(tc.in, config.Decoder{
+			StaticMap: map[string]string{"0x1": "refs", "0x2": "slow", "0x3": "miss"},
+		})
+		if err != nil {
+			t.Error(err)
+		}
+		if out != tc.v || lout != tc.l {
+			t.Errorf("Expected %s(%d), got %s(%d)", tc.v, tc.l, out, lout)
+		}
+	}
+}

--- a/decoder/string.go
+++ b/decoder/string.go
@@ -1,7 +1,7 @@
 package decoder
 
 import (
-	"strings"
+	"fmt"
 
 	"github.com/cloudflare/ebpf_exporter/config"
 )
@@ -10,6 +10,27 @@ import (
 type String struct{}
 
 // Decode transforms strings coming from the kernel
-func (s *String) Decode(in string, conf config.Decoder) (string, error) {
-	return strings.Trim(in, "\""), nil
+func (s *String) Decode(in string, conf config.Decoder) (string, int, error) {
+	var found bool
+	var start, end, i int
+	for i = 0; i < len(in); i++ {
+		if in[i] == '"' {
+			if !found {
+				found = true
+				start = i
+			} else {
+				end = i
+			}
+		}
+		if start > 0 && end > 0 {
+			break
+		}
+	}
+	if !found {
+		return in, len(in), nil
+	}
+	if end == 0 {
+		return "", i, fmt.Errorf("mismatched quotes, start=%d end=%d", start, end)
+	}
+	return in[start+1 : end], end, nil
 }

--- a/decoder/string_test.go
+++ b/decoder/string_test.go
@@ -1,0 +1,29 @@
+package decoder
+
+import (
+	"testing"
+
+	"github.com/cloudflare/ebpf_exporter/config"
+)
+
+func TestStringDecode(t *testing.T) {
+	for _, tc := range []struct {
+		in string
+		v  string
+		l  int
+	}{
+		{`"hello" testing`, "hello", 6},
+		{`"hello"`, "hello", 6},
+		{`hello`, "hello", 5},
+		{`hello world`, "hello world", 11},
+	} {
+		s := &String{}
+		out, lout, err := s.Decode(tc.in, config.Decoder{})
+		if err != nil {
+			t.Error(err)
+		}
+		if out != tc.v || lout != tc.l {
+			t.Errorf("Expected %s(%d), got %s(%d)", tc.v, tc.l, out, lout)
+		}
+	}
+}

--- a/decoder/uint64.go
+++ b/decoder/uint64.go
@@ -1,6 +1,7 @@
 package decoder
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/cloudflare/ebpf_exporter/config"
@@ -10,11 +11,15 @@ import (
 type UInt64 struct{}
 
 // Decode transforms hex numbers into regular numbers
-func (u *UInt64) Decode(in string, conf config.Decoder) (string, error) {
-	num, err := strconv.ParseUint(in, 0, 64)
+func (u *UInt64) Decode(in string, conf config.Decoder) (string, int, error) {
+	var val string
+	if _, err := fmt.Sscan(in, &val); err != nil {
+		return "", 0, err
+	}
+	num, err := strconv.ParseUint(val, 0, 64)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 
-	return strconv.Itoa(int(num)), nil
+	return strconv.Itoa(int(num)), len(val), nil
 }

--- a/decoder/uint64_test.go
+++ b/decoder/uint64_test.go
@@ -1,0 +1,27 @@
+package decoder
+
+import (
+	"testing"
+
+	"github.com/cloudflare/ebpf_exporter/config"
+)
+
+func TestUInt64Decode(t *testing.T) {
+	for _, tc := range []struct {
+		in string
+		v  string
+		l  int
+	}{
+		{`0x2 testing`, "2", 3},
+		{`2 hello"`, "2", 1},
+	} {
+		s := &UInt64{}
+		out, lout, err := s.Decode(tc.in, config.Decoder{})
+		if err != nil {
+			t.Error(err)
+		}
+		if out != tc.v || lout != tc.l {
+			t.Errorf("Expected %s(%d), got %s(%d)", tc.v, tc.l, out, lout)
+		}
+	}
+}

--- a/examples/dcstat.yaml
+++ b/examples/dcstat.yaml
@@ -11,7 +11,7 @@ programs:
           labels:
             - name: op
               decoders:
-                - name: uint
+                - name: uint64
                 - name: static_map
                   static_map:
                     1: refs

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -56,8 +56,24 @@ func TestDecodeLabel(t *testing.T) {
 			e := &Exporter{decoders: decoder.NewSet()}
 			decoded, _, err := e.extractLabels(tc.key, tc.labels)
 			if !reflect.DeepEqual(decoded, tc.expected) {
-				t.Errorf("failed to decode: expected(%v), got decoded=%v, err=%q", tc.expected, decoded, err)
+				t.Errorf("failed to decode: expected(%v), got decoded=%v, err=%v", tc.expected, decoded, err)
 			}
 		})
+	}
+}
+
+func TestNextValidToken(t *testing.T) {
+	for _, tc := range []struct {
+		s        string
+		i        int
+		expected int
+	}{
+		{"asd ", 0, 0},
+		{"asd h", 3, 4},
+		{"  h", 0, 2},
+	} {
+		if res := nextValidToken(tc.s, tc.i); res != tc.expected {
+			t.Errorf("failed s=%q, i=%d, res=%d, expected=%d", tc.s, tc.i, res, tc.expected)
+		}
 	}
 }

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -1,0 +1,63 @@
+package exporter
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cloudflare/ebpf_exporter/config"
+	"github.com/cloudflare/ebpf_exporter/decoder"
+)
+
+func TestDecodeLabel(t *testing.T) {
+	for _, tc := range []struct {
+		key      string
+		labels   []config.Label
+		expected []string
+	}{
+		{
+			key: `0x2 "Handler-main"`,
+			labels: []config.Label{
+				{
+					Name: "op",
+					Decoders: []config.Decoder{
+						{Name: "uint64"},
+						{Name: "static_map", StaticMap: map[string]string{"1": "refs", "2": "slow", "3": "miss"}},
+					},
+				},
+				{
+					Name: "command",
+					Decoders: []config.Decoder{
+						{Name: "string"},
+					},
+				},
+			},
+			expected: []string{"slow", "Handler-main"},
+		},
+		{
+			key: `0x2 "tmux: server"`,
+			labels: []config.Label{
+				{
+					Name: "op",
+					Decoders: []config.Decoder{
+						{Name: "static_map", StaticMap: map[string]string{"0x1": "refs", "0x2": "slow", "0x3": "miss"}},
+					},
+				},
+				{
+					Name: "command",
+					Decoders: []config.Decoder{
+						{Name: "string"},
+					},
+				},
+			},
+			expected: []string{"slow", "tmux: server"},
+		},
+	} {
+		t.Run(tc.key, func(t *testing.T) {
+			e := &Exporter{decoders: decoder.NewSet()}
+			decoded, _, err := e.extractLabels(tc.key, tc.labels)
+			if !reflect.DeepEqual(decoded, tc.expected) {
+				t.Errorf("failed to decode: expected(%v), got decoded=%v, err=%q", tc.expected, decoded, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
currently we split fields using space separator. But this failed in case program has space in name. For example "tmux: server". This refactor the current decoders into simple index-based decoders to let them have greater flexibility in parsing its required data.

Before:
```
Error getting table "counts" values for metric "dcache_ops_total" of program "dcstat": key "{ 0x1 \"tmux: server\" }" has 3 elements, but we expect 2
```

After:
```
ebpf_exporter_dcache_ops_total{command="tmux: server",op="refs"} 2517
```