### PR TITLE
Add ipcstat example to calculate instructions per cycle

### DIFF
--- a/examples/ipcstat.yaml
+++ b/examples/ipcstat.yaml
@@ -1,0 +1,47 @@
+programs:
+  # See:
+  # * http://www.brendangregg.com/blog/2017-05-09/cpu-utilization-is-wrong.html
+  - name: ipcstat
+    metrics:
+      counters:
+        - name: cpu_instructions_total
+          help: Instructions retired by CPUs
+          table: instructions
+          labels:
+            - name: cpu
+              decoders:
+                - name: uint64
+        - name: cpu_cycles_total
+          help: Cycles processed by CPUs
+          table: cycles
+          labels:
+            - name: cpu
+              decoders:
+                - name: uint64
+    perf_events:
+      - type: 0x0 # HARDWARE
+        name: 0x1 # PERF_COUNT_HW_INSTRUCTIONS
+        target: on_cpu_instruction
+        sample_period: 1000000
+      - type: 0x0 # HARDWARE
+        name: 0x0 # PERF_COUNT_HW_CPU_CYCLES
+        target: on_cpu_cycle
+        sample_period: 1000000
+    code: |
+      #include <linux/ptrace.h>
+      #include <uapi/linux/bpf_perf_event.h>
+
+      const int max_cpus = 128;
+
+      BPF_ARRAY(instructions, u64, max_cpus);
+      BPF_ARRAY(cycles, u64, max_cpus);
+
+      int on_cpu_instruction(struct bpf_perf_event_data *ctx) {
+          instructions.increment(bpf_get_smp_processor_id());
+          return 0;
+      }
+
+      int on_cpu_cycle(struct bpf_perf_event_data *ctx) {
+          cycles.increment(bpf_get_smp_processor_id());
+          return 0;
+      }


### PR DESCRIPTION
This depends on #16 for `perf_event` support. We measure every 1 million
events for each, that may be too much for a busy CPU to handle.

Inspiration can be found here:

* http://www.brendangregg.com/blog/2017-05-09/cpu-utilization-is-wrong.html