### PR TITLE
Remove unnecessary uapi/linux/ptrace.h include

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,6 @@ programs:
       blk_mq_start_request: trace_req_start
       blk_account_io_completion: trace_req_completion
     code: |
-      #include <uapi/linux/ptrace.h>
       #include <linux/blkdev.h>
       #include <linux/blk_types.h>
 

--- a/examples/bio.yaml
+++ b/examples/bio.yaml
@@ -54,7 +54,6 @@ programs:
       blk_mq_start_request: trace_req_start
       blk_account_io_completion: trace_req_completion
     code: |
-      #include <uapi/linux/ptrace.h>
       #include <linux/blkdev.h>
       #include <linux/blk_types.h>
 

--- a/examples/runqlat.yaml
+++ b/examples/runqlat.yaml
@@ -21,7 +21,6 @@ programs:
       wake_up_new_task: trace_wake_up_new_task
       finish_task_switch: trace_run
     code: |
-      #include <uapi/linux/ptrace.h>
       #include <linux/sched.h>
 
       // 27 buckets for latency, max range is 33.6s .. 67.1s


### PR DESCRIPTION
It's only needed for `struct pt_regs`:

* https://github.com/iovisor/bcc/issues/1771