### PR TITLE
Do not register empty exporter in prometheus

### DIFF
--- a/cmd/ebpf_exporter/main.go
+++ b/cmd/ebpf_exporter/main.go
@@ -34,9 +34,15 @@ func main() {
 		log.Fatalf("Error attaching exporter: %s", err)
 	}
 
-	err = prometheus.Register(e)
-	if err != nil {
-		log.Fatalf("Error registering exporter: %s", err)
+	log.Printf("Starting with %d programs found in the config", len(config.Programs))
+
+	// Do not register exporter if there are no programs,
+	// it will fail in prometheus code
+	if len(config.Programs) > 0 {
+		err = prometheus.Register(e)
+		if err != nil {
+			log.Fatalf("Error registering exporter: %s", err)
+		}
 	}
 
 	http.Handle("/metrics", promhttp.Handler())


### PR DESCRIPTION
This allows running exporter with arbitrary number of programs
without running into this error:

```
Error registering exporter: collector has no descriptors
```