### PR TITLE
Skip zero device from blkid in tracepoint based bio

### DIFF
--- a/examples/bio-tracepoints.yaml
+++ b/examples/bio-tracepoints.yaml
@@ -97,6 +97,11 @@ programs:
 
       // Generates function tracepoint__block__block_rq_issue
       TRACEPOINT_PROBE(block, block_rq_issue) {
+          // blkid generates these and we're not interested in them
+          if (args->dev == 0) {
+              return 0;
+          }
+
           struct key_t key = {};
           key.dev = args->dev;
           key.sector = args->sector;


### PR DESCRIPTION
```
$ sudo perf record -g -e block:block_rq_complete
```

```
$ sudo blkid /dev/sda
```

```
$ sudo perf script
blkid 28996 [039] 13951115.696645: block:block_rq_complete: 0,0 N () 18446744073709551615 + 0 [0]
            7fffa5a2dc02 blk_update_request ([kernel.kallsyms])
                   db730 write (/lib/x86_64-linux-gnu/libc-2.24.so)
        6566322d30333762 [unknown] ([unknown])
```