### PR TITLE
Use sampling frequency instead of sampling period

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,7 +691,11 @@ See [llcstat](examples/llcstat.yaml) as an example.
   name: [ perf event name code ]
   target: [ target eBPF function ]
   sample_period: [ sample period ]
+  sample_frequency: [ sample frequency ]
 ```
+
+It's preferred to use `sample_frequency` to let kernel pick the sample period
+automatically, otherwise you may end up with invalid metrics on overflow.
 
 #### `metrics`
 

--- a/config/config.go
+++ b/config/config.go
@@ -18,10 +18,11 @@ type Program struct {
 
 // PerfEvent describes perf_event to attach to
 type PerfEvent struct {
-	Type         int    `yaml:"string"`
-	Name         int    `yaml:"name"`
-	Target       string `yaml:"target"`
-	SamplePeriod int    `yaml:"sample_period"`
+	Type            int    `yaml:"string"`
+	Name            int    `yaml:"name"`
+	Target          string `yaml:"target"`
+	SamplePeriod    int    `yaml:"sample_period"`
+	SampleFrequency int    `yaml:"sample_frequency"`
 }
 
 // Metrics is a collection of metrics attached to a program

--- a/examples/ipcstat.yaml
+++ b/examples/ipcstat.yaml
@@ -24,11 +24,11 @@ programs:
       - type: 0x0 # HARDWARE
         name: 0x1 # PERF_COUNT_HW_INSTRUCTIONS
         target: on_cpu_instruction
-        sample_period: 1000000
+        sample_frequency: 99
       - type: 0x0 # HARDWARE
         name: 0x0 # PERF_COUNT_HW_CPU_CYCLES
         target: on_cpu_cycle
-        sample_period: 1000000
+        sample_frequency: 99
     code: |
       #include <linux/ptrace.h>
       #include <uapi/linux/bpf_perf_event.h>
@@ -39,11 +39,11 @@ programs:
       BPF_ARRAY(cycles, u64, max_cpus);
 
       int on_cpu_instruction(struct bpf_perf_event_data *ctx) {
-          instructions.increment(bpf_get_smp_processor_id());
+          instructions.increment(bpf_get_smp_processor_id(), ctx->sample_period);
           return 0;
       }
 
       int on_cpu_cycle(struct bpf_perf_event_data *ctx) {
-          cycles.increment(bpf_get_smp_processor_id());
+          cycles.increment(bpf_get_smp_processor_id(), ctx->sample_period);
           return 0;
       }

--- a/examples/llcstat.yaml
+++ b/examples/llcstat.yaml
@@ -25,11 +25,11 @@ programs:
       - type: 0x0 # HARDWARE
         name: 0x3 # PERF_COUNT_HW_CACHE_MISSES
         target: on_cache_miss
-        sample_period: 1000
+        sample_frequency: 99
       - type: 0x0 # HARDWARE
         name: 0x2 # PERF_COUNT_HW_CACHE_REFERENCES
         target: on_cache_reference
-        sample_period: 1000
+        sample_frequency: 99
     code: |
       #include <linux/ptrace.h>
       #include <uapi/linux/bpf_perf_event.h>
@@ -40,11 +40,11 @@ programs:
       BPF_ARRAY(misses, u64, max_cpus);
 
       int on_cache_miss(struct bpf_perf_event_data *ctx) {
-          misses.increment(bpf_get_smp_processor_id());
+          misses.increment(bpf_get_smp_processor_id(), ctx->sample_period);
           return 0;
       }
 
       int on_cache_reference(struct bpf_perf_event_data *ctx) {
-          references.increment(bpf_get_smp_processor_id());
+          references.increment(bpf_get_smp_processor_id(), ctx->sample_period);
           return 0;
       }

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -74,7 +74,7 @@ func (e *Exporter) Attach() error {
 				return fmt.Errorf("failed to load target %q in program %q: %s", perfEventConfig.Target, program.Name, err)
 			}
 
-			err = module.AttachPerfEvent(perfEventConfig.Type, perfEventConfig.Name, perfEventConfig.SamplePeriod, 0, -1, -1, -1, target)
+			err = module.AttachPerfEvent(perfEventConfig.Type, perfEventConfig.Name, perfEventConfig.SamplePeriod, perfEventConfig.SampleFrequency, -1, -1, -1, target)
 			if err != nil {
 				return fmt.Errorf("failed to attach perf event %d:%d to %q in program %q: %s", perfEventConfig.Type, perfEventConfig.Name, perfEventConfig.Target, program.Name, err)
 			}


### PR DESCRIPTION
For high frequency events it's easy to pick a wrong sampling period, which leaves users with invalid data. See how `ipcstat` may be affected:

* https://github.com/iovisor/bcc/issues/1757#issuecomment-417213540

When using sampling frequency instead of sampling period, kernel dynamically adjusts sampling period to achieve the target rate:

* https://perf.wiki.kernel.org/index.php/Tutorial#Event-based_sampling_overview