### PR TITLE
Add shrinklat and xfs_reclaim examples

### DIFF
--- a/examples/shrinklat.yaml
+++ b/examples/shrinklat.yaml
@@ -1,0 +1,67 @@
+programs:
+  # Track shrink_node latency, mainly for purposes of seeing latecy
+  # of memory allocation slowpath.
+  - name: shrinklat
+    metrics:
+      histograms:
+        - name: shrink_node_latency_seconds
+          help: Latency histogram for shrink_node calls
+          table: shrink_node_latency
+          bucket_type: exp2
+          bucket_min: 0
+          bucket_max: 26
+          bucket_multiplier: 0.000001 # microseconds to seconds
+          labels:
+            - name: bucket
+              size: 8
+              decoders:
+                - name: uint
+    kprobes:
+      shrink_node: shrink_node_start
+    kretprobes:
+      shrink_node: shrink_node_end
+    code: |
+      #include <uapi/linux/ptrace.h>
+
+      // 27 buckets for latency, max range is 33.6s .. 67.1s
+      const u8 max_latency_slot = 26;
+
+      // Histograms to record latencies
+      BPF_HISTOGRAM(shrink_node_latency, u64, max_latency_slot + 1);
+
+      // Pid to start time map
+      BPF_HASH(start, u32);
+
+      int shrink_node_start(struct pt_regs *ctx) {
+          u32 pid = bpf_get_current_pid_tgid();
+
+          u64 ts = bpf_ktime_get_ns();
+          start.update(&pid, &ts);
+
+          return 0;
+      }
+
+      int shrink_node_end(struct pt_regs *ctx) {
+          u32 pid = bpf_get_current_pid_tgid();
+
+          u64 *tsp = start.lookup(&pid);
+          if (tsp == 0) {
+              return 0;
+          }
+
+          // Latency histogram key
+          u64 latency_slot = bpf_log2l((bpf_ktime_get_ns() - *tsp) / 1000);
+
+          // Cap latency bucket at max value
+          if (latency_slot > max_latency_slot) {
+              latency_slot = max_latency_slot;
+          }
+
+          // Increment bucket key
+          shrink_node_latency.increment(latency_slot);
+
+          // Remove started task
+          start.delete(&pid);
+
+          return 0;
+      }

--- a/examples/xfs_reclaim.yaml
+++ b/examples/xfs_reclaim.yaml
@@ -1,0 +1,123 @@
+programs:
+  # Track XFS reclaim latency for both search and free phases. This is called
+  # from direct reclaim path, which means it impacts memory allocation slowpath.
+  - name: xfs_reclaim
+    metrics:
+      histograms:
+        - name: xfs_reclaim_latency_seconds
+          help: Latency histogram for xfs reclaim operations
+          table: xfs_reclaim_latency
+          bucket_type: exp2
+          bucket_min: 0
+          bucket_max: 26
+          bucket_multiplier: 0.000001 # microseconds to seconds
+          labels:
+            - name: operation
+              size: 8
+              decoders:
+                - name: uint
+                - name: static_map
+                  static_map:
+                    1: count
+                    2: free
+            - name: bucket
+              size: 8
+              decoders:
+                - name: uint
+    kprobes:
+      xfs_fs_nr_cached_objects: xfs_fs_nr_cached_objects_start
+      xfs_fs_free_cached_objects: xfs_fs_free_cached_objects_start
+    kretprobes:
+      xfs_fs_nr_cached_objects: xfs_fs_nr_cached_objects_end
+      xfs_fs_free_cached_objects: xfs_fs_free_cached_objects_end
+    code: |
+      #include <uapi/linux/ptrace.h>
+
+      // 27 buckets for latency, max range is 33.6s .. 67.1s
+      const u8 max_latency_slot = 26;
+
+      // Key for latency measurements map
+      struct latency_key_t {
+          u8 op;
+          u64 slot;
+      };
+
+      // Histograms to record latencies (2 is the number of ops in reclaim_op)
+      BPF_HISTOGRAM(xfs_reclaim_latency, struct latency_key_t, max_latency_slot + 1 * 2);
+
+      // Possible reclaim operations
+      enum reclaim_op {
+          S_COUNT = 1,
+          S_FREE  = 2
+      };
+
+      // Key for tracking operations
+      struct start_key_t {
+          u32 pid;
+          enum reclaim_op op;
+      };
+
+      // Map for tracking operation start time
+      BPF_HASH(start, struct start_key_t);
+
+      // Track operation start
+      static int op_start(u32 pid, enum reclaim_op op) {
+          struct start_key_t key = {};
+
+          key.pid = pid;
+          key.op  = op;
+
+          u64 ts = bpf_ktime_get_ns();
+          start.update(&key, &ts);
+
+          return 0;
+      }
+
+      // Track operation completion and update latenct histogram
+      static int op_end(u32 pid, enum reclaim_op op) {
+          struct start_key_t key = {};
+
+          key.pid = pid;
+          key.op  = op;
+
+          u64 *tsp = start.lookup(&key);
+
+          if (tsp == 0) {
+              return 0;
+          }
+
+          // Latency histogram key
+          u64 latency_slot = bpf_log2l((bpf_ktime_get_ns() - *tsp) / 1000);
+
+          // Cap latency bucket at max value
+          if (latency_slot > max_latency_slot) {
+              latency_slot = max_latency_slot;
+          }
+
+          struct latency_key_t latency_key = {};
+          latency_key.op   = op;
+          latency_key.slot = latency_slot;
+
+          xfs_reclaim_latency.increment(latency_key);
+
+          // Remove started task
+          start.delete(&key);
+
+          return 0;
+      }
+
+      int xfs_fs_nr_cached_objects_start(struct pt_regs *ctx) {
+          return op_start(bpf_get_current_pid_tgid(), S_COUNT);
+      }
+
+      int xfs_fs_nr_cached_objects_end(struct pt_regs *ctx) {
+          return op_end(bpf_get_current_pid_tgid(), S_COUNT);
+      }
+
+      int xfs_fs_free_cached_objects_start(struct pt_regs *ctx) {
+          return op_start(bpf_get_current_pid_tgid(), S_FREE);
+      }
+
+      int xfs_fs_free_cached_objects_end(struct pt_regs *ctx) {
+          return op_end(bpf_get_current_pid_tgid(), S_FREE);
+      }


### PR DESCRIPTION
This is quite eye opening in terms of how bad page allocation slow path can be:

![image](https://user-images.githubusercontent.com/89186/49122113-f02f8700-f267-11e8-86af-ba5f9e631f44.png)

Multiple XFS filesystem in turn show this picture:

![image](https://user-images.githubusercontent.com/89186/49122128-03daed80-f268-11e8-8724-dce897790da8.png)

The culprit appears to be the desire to flush as many inodes from cache as possible, not matter if they are dirty or clean. This doesn't play very well when a system has 100GB of page cache and 1GB of dirty pages that can be flushed on disk. Kernel opts into flushing pages on (potentially very slow) storage, while page cache can be reclaimed at near zero cost.