### PR TITLE
add cflags for bcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,10 @@ raw_tracepoints:
 # Perf events configuration
 perf_events:
   [ - perf_event ]
+# Cflags are passed to the bcc compiler, useful for preprocessing
+cflags:
+  [ - -I/include/path
+    - -DMACRO_NAME=value ]
 # Actual eBPF program code to inject in the kernel
 code: [ code ]
 ```

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type Program struct {
 	RawTracepoints map[string]string `yaml:"raw_tracepoints"`
 	PerfEvents     []PerfEvent       `yaml:"perf_events"`
 	Code           string            `yaml:"code"`
+	Cflags         []string          `yaml:"cflags"`
 }
 
 // PerfEvent describes perf_event to attach to

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -62,7 +62,7 @@ func (e *Exporter) Attach() error {
 			return fmt.Errorf("multiple programs with name %q", program.Name)
 		}
 
-		module := bcc.NewModule(program.Code, []string{})
+		module := bcc.NewModule(program.Code, program.Cflags)
 		if module == nil {
 			return fmt.Errorf("error compiling module for program %q", program.Name)
 		}


### PR DESCRIPTION
Sometimes we just need to pass cflags to bcc. For example, to use alternate include directories:
```
    ...
    cflags:
      - -I/usr/local/include
      - -I/opt/project/include
    code: |
    ...
```
