### PR TITLE
add dname decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,6 +655,20 @@ An example to match `1` to `read` and `2` to `write`:
 String decoder transforms possibly null terminated strings coming
 from the kernel into string usable for prometheus metrics.
 
+#### `dname`
+
+Dname decoder read DNS qname from string in wire format, then decode
+it into '.' notation format. Could be used after `string` decoder.
+E.g.: `\x07example\03com\x00` will become `example.com`. This decoder
+could be used after `string` decode, like the following example:
+
+```
+- name: qname
+  decoders:
+    - name: string
+	- name: dname
+```
+
 #### `uint`
 
 UInt decoder transforms hex encoded `uint` values from the kernel

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -31,6 +31,7 @@ func NewSet() *Set {
 			"regexp":     &Regexp{},
 			"static_map": &StaticMap{},
 			"string":     &String{},
+			"dname":      &Dname{},
 			"uint":       &UInt{},
 			"inet_ip":    &InetIP{},
 		},

--- a/decoder/dname.go
+++ b/decoder/dname.go
@@ -1,0 +1,32 @@
+package decoder
+
+import (
+	"github.com/cloudflare/ebpf_exporter/config"
+)
+
+// Dname is a decoder that decodes DNS qname wire format
+type Dname struct{}
+
+// Decode transforms wire format into string
+func (d *Dname) Decode(in []byte, conf config.Decoder) ([]byte, error) {
+	if len(in) == 0 {
+		return []byte("."), nil
+	}
+
+	out := make([]byte, len(in))
+	for off := 0; off < len(in); {
+		n := int(in[off])
+		// change length byte into "."
+		out[off] = '.'
+		off++
+		if off+n > len(in) {
+			return in, nil
+		}
+
+		copy(out[off:off+n], in[off:off+n])
+		off += n
+	}
+
+	// ignore the leading "."
+	return out[1:], nil
+}

--- a/decoder/dname_test.go
+++ b/decoder/dname_test.go
@@ -1,0 +1,45 @@
+package decoder
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cloudflare/ebpf_exporter/config"
+)
+
+func TestDnameDecoder(t *testing.T) {
+	cases := []struct {
+		in  []byte
+		out []byte
+	}{
+		{
+			in:  []byte(""),
+			out: []byte("."),
+		},
+		{
+			in:  []byte("\x03com"),
+			out: []byte("com"),
+		},
+		{
+			in:  []byte("\x07example\x03com"),
+			out: []byte("example.com"),
+		},
+		{
+			in:  []byte("\x05com"),
+			out: []byte("\x05com"),
+		},
+	}
+
+	for _, c := range cases {
+		d := &Dname{}
+
+		out, err := d.Decode(c.in, config.Decoder{})
+		if err != nil {
+			t.Errorf("Error decoding %#v to %#v: %s", c.in, c.out, err)
+		}
+
+		if !bytes.Equal(out, c.out) {
+			t.Errorf("Expected %s, got %s", c.out, out)
+		}
+	}
+}

--- a/decoder/string.go
+++ b/decoder/string.go
@@ -4,7 +4,7 @@ import (
 	"github.com/cloudflare/ebpf_exporter/config"
 )
 
-// String is a decoded that decodes strings coming from the kernel
+// String is a decoder that decodes strings coming from the kernel
 type String struct{}
 
 // Decode transforms byte slice from the kernel into string


### PR DESCRIPTION
This decoder will convert DNS qname wire format into human readable
"." notation domain name.