### PR TITLE
Fix docker build using libbcc 0.10.0-1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648A4A16A23015EEF4A66B8E4052245BD4284CDD && \
     echo "deb https://repo.iovisor.org/apt/xenial xenial main" > /etc/apt/sources.list.d/iovisor.list && \
     apt-get update && \
-    apt-get install -y libbcc=0.9.0-1 linux-headers-amd64
+    apt-get install -y libbcc=0.10.0-1 linux-headers-amd64
 
 COPY ./ /go/ebpf_exporter
 


### PR DESCRIPTION
Fixes issue: https://github.com/cloudflare/ebpf_exporter/issues/55

Seems that libbcc 0.9.0-1 is no longer available in the xenial repo, whereas 0.10.0-1 is.
See: https://repo.iovisor.org/apt/xenial/dists/xenial/main/binary-amd64/Packages