### PR TITLE
Only test released Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: go
 
 go:
   - 1.x
-  - master
 
 before_install:
   # We're not interested in gopath provided by travis, default ~/go is good


### PR DESCRIPTION
Currently Go tip is not entirely happy with modules from Go 1.13, but it's not something we care about until Go 1.14 is out.