### PR TITLE
Add cgroup decoder to map cgroup id to cgroup path

### DIFF
--- a/decoder/cgroup.go
+++ b/decoder/cgroup.go
@@ -1,0 +1,72 @@
+ package decoder
+
+import (
+  "os"
+  "fmt"
+  "log"
+  "strconv"
+  "path/filepath"
+
+  "golang.org/x/sys/unix"
+	"github.com/cloudflare/ebpf_exporter/config"
+  "github.com/iovisor/gobpf/bcc"
+)
+
+// CGroup is a decoder that transforms cgroup id to path in cgroupfs
+type CGroup struct {
+	cache map[uint64][]byte
+}
+
+// Decode transforms cgroup id to path in cgroupfs
+func (c *CGroup) Decode(in []byte, conf config.Decoder) ([]byte, error) {
+  if c.cache == nil {
+    c.cache = map[uint64][]byte{}
+  }
+
+  cgroupID, err := strconv.Atoi(string(in))
+  if err != nil {
+    return nil, err
+  }
+
+  if path, ok := c.cache[uint64(cgroupID)]; ok {
+    return path, nil
+  }
+
+  if err = c.refreshCache(); err != nil {
+    log.Printf("Error refreshing cgroup id to path map: %s", err)
+  }
+
+  if path, ok := c.cache[uint64(cgroupID)]; ok {
+    return path, nil
+  }
+
+  return []byte(fmt.Sprintf("unknown_cgroup_id:%d", cgroupID)), nil
+}
+
+func (c *CGroup) refreshCache() error {
+  byteOrder := bcc.GetHostByteOrder()
+
+  cgroupPath := "/sys/fs/cgroup/unified"
+  if _, err := os.Stat(cgroupPath); os.IsNotExist(err) {
+    cgroupPath = "/sys/fs/cgroup"
+  }
+
+  return filepath.Walk(cgroupPath, func(path string, info os.FileInfo, err error) error {
+    if err != nil {
+      return err
+    }
+
+    if !info.IsDir() {
+      return nil
+    }
+
+    handle, _, err := unix.NameToHandleAt(unix.AT_FDCWD, path, 0)
+    if err != nil {
+      log.Printf("Error resolving handle of %s: %s", path, err)
+    }
+
+    c.cache[byteOrder.Uint64(handle.Bytes())] = []byte(path)
+
+    return nil
+  })
+}

--- a/decoder/cgroup_test.go
+++ b/decoder/cgroup_test.go
@@ -1,0 +1,40 @@
+package decoder
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cloudflare/ebpf_exporter/config"
+)
+
+func TestCgroupDecoder(t *testing.T) {
+	cases := []struct {
+		in    []byte
+		cache map[uint64][]byte
+		out   []byte
+	}{
+		{
+			in:    []byte("6"),
+			cache: map[uint64][]byte{uint64(6): []byte("cgroup_six")},
+			out:   []byte("cgroup_six"),
+		},
+		{
+			in:    []byte("6"),
+			cache: map[uint64][]byte{uint64(7): []byte("cgroup_seven")},
+			out:   []byte("unknown_cgroup_id:6"),
+		},
+	}
+
+	for _, c := range cases {
+		d := &CGroup{cache: c.cache}
+
+		out, err := d.Decode(c.in, config.Decoder{})
+		if err != nil {
+			t.Errorf("Error decoding %#v with cache set to %#v: %s", c.in, c.cache, err)
+		}
+
+		if !bytes.Equal(out, c.out) {
+			t.Errorf("Expected %s, got %s", c.out, out)
+		}
+	}
+}

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -28,6 +28,7 @@ type Set struct {
 func NewSet() *Set {
 	return &Set{
 		decoders: map[string]Decoder{
+			"cgroup":     &CGroup{},
 			"ksym":       &KSym{},
 			"majorminor": &MajorMinor{},
 			"regexp":     &Regexp{},

--- a/examples/cgroup.yaml
+++ b/examples/cgroup.yaml
@@ -1,0 +1,24 @@
+programs:
+  # Count open() syscalls by cgroup
+  - name: cgroup
+    metrics:
+      counters:
+        - name: cgroup_open_calls_total
+          help: Calls to open() from cgroups
+          table: counts
+          labels:
+            - name: cgroup
+              size: 8
+              decoders:
+                - name: uint
+                - name: cgroup
+    tracepoints:
+      syscalls:sys_enter_open: tracepoint__syscalls__sys_enter_open
+    code: |
+      BPF_HASH(counts, u64);
+
+      // Generates function tracepoint__syscalls__sys_enter_open
+      TRACEPOINT_PROBE(syscalls, sys_enter_open) {
+          counts.increment((u64) bpf_get_current_cgroup_id());
+          return 0;
+      }


### PR DESCRIPTION
Metrics from the example:

```
$ curl -s http://localhost:9435/metrics | grep ebpf_exporter_cgroup_open_calls_total
ebpf_exporter_cgroup_open_calls_total{cgroup="/sys/fs/cgroup/unified/init.scope"} 29163
ebpf_exporter_cgroup_open_calls_total{cgroup="/sys/fs/cgroup/unified/system.slice/conntrack-stats-exporter.service"} 100
ebpf_exporter_cgroup_open_calls_total{cgroup="/sys/fs/cgroup/unified/system.slice/cron.service"} 20439
ebpf_exporter_cgroup_open_calls_total{cgroup="/sys/fs/cgroup/unified/system.slice/dbus.service"} 88
ebpf_exporter_cgroup_open_calls_total{cgroup="/sys/fs/cgroup/unified/system.slice/docker.service"} 51
ebpf_exporter_cgroup_open_calls_total{cgroup="/sys/fs/cgroup/unified/system.slice/lldpd.service"} 2
ebpf_exporter_cgroup_open_calls_total{cgroup="/sys/fs/cgroup/unified/system.slice/salt-minion.service"} 67
ebpf_exporter_cgroup_open_calls_total{cgroup="/sys/fs/cgroup/unified/system.slice/syslog-ng.service"} 42
ebpf_exporter_cgroup_open_calls_total{cgroup="/sys/fs/cgroup/unified/system.slice/systemd-journald.service"} 2547
ebpf_exporter_cgroup_open_calls_total{cgroup="/sys/fs/cgroup/unified/system.slice/systemd-networkd.service"} 20
ebpf_exporter_cgroup_open_calls_total{cgroup="/sys/fs/cgroup/unified/system.slice/systemd-resolved.service"} 5
ebpf_exporter_cgroup_open_calls_total{cgroup="/sys/fs/cgroup/unified/user.slice/user-4076.slice/session-271566.scope"} 165
ebpf_exporter_cgroup_open_calls_total{cgroup="/sys/fs/cgroup/unified/user.slice/user-4076.slice/user@4076.service/init.scope"} 523
ebpf_exporter_cgroup_open_calls_total{cgroup="/sys/fs/cgroup/unified/user.slice/user-4079.slice/user@4079.service/init.scope"} 523
ebpf_exporter_cgroup_open_calls_total{cgroup="/sys/fs/cgroup/unified/user.slice/user-4406.slice/user@4406.service/init.scope"} 523
```

This requires Linux 4.18 and newer:

* https://github.com/torvalds/linux/commit/bf6fa2c893c5237b48569a13fa3c673041430b6c

Closes #13