### PR TITLE
examples: add tcpsynbl.yaml for tracing the TCP SYN backlog

### DIFF
--- a/examples/tcpsynbl.yaml
+++ b/examples/tcpsynbl.yaml
@@ -1,0 +1,30 @@
+programs:
+  - name: tcpsynbl
+    metrics:
+      histograms:
+        - name: tcp_syn_backlog
+          help: trace the TCP SYN backlog size
+          table: bucket
+          bucket_type: linear
+          bucket_min: 0
+          bucket_max: 1024 # `sysctl net.ipv4.tcp_max_syn_backlog`
+          bucket_multiplier: 1
+          labels:
+            - name: bucket
+              size: 8
+              decoders:
+                - name: uint
+    kprobes:
+      tcp_v4_syn_recv_sock: do_count
+      tcp_v6_syn_recv_sock: do_count
+    code: |
+      #include <net/sock.h>
+
+      // Histograms to record TCP SYN backlog size
+      BPF_HISTOGRAM(bucket, u64);
+
+      int do_count(struct pt_regs *ctx, struct sock *sk) {
+          u64 backlog = bpf_log2l(sk->sk_ack_backlog);
+          bucket.increment(backlog);
+          return 0;
+      }

--- a/examples/tcpsynbl.yaml
+++ b/examples/tcpsynbl.yaml
@@ -3,7 +3,7 @@ programs:
     metrics:
       histograms:
         - name: tcp_syn_backlog
-          help: trace the TCP SYN backlog size
+          help: TCP SYN backlog size
           table: bucket
           bucket_type: linear
           bucket_min: 0

--- a/examples/tcpsynbl.yaml
+++ b/examples/tcpsynbl.yaml
@@ -7,8 +7,8 @@ programs:
           table: bucket
           bucket_type: linear
           bucket_min: 0
-          bucket_max: 1024 # `sysctl net.ipv4.tcp_max_syn_backlog`
-          bucket_multiplier: 1
+          bucket_max: 20
+          bucket_multiplier: 50
           labels:
             - name: bucket
               size: 8


### PR DESCRIPTION
Background:

There are two types of backlogs when TCP connection happens:

- SYN Backlog, which buffers connections on receiving SYN packets
- Listen Backlog, which buffers connections after sockets are ESTABLISHED but before accepted by applications

In the world of web programming, it is often userful to monitor the size of backlogs,
and find out whether we need to increase the number of backlogs limit.

ebpf_exporter achieves that you can collect those metrics in a histogram and export,
and can nicely visualize in Grafana dashboard for example.

---

@bobrik Hi 👋 I have been looking for collecting the TCP SYN backlog, and found out that `cloudflare/ebpf_exporter` let me to monitor the information, and can integrate with our alerting system smoothly using Prometheus and AlertManager 👍 

So I have just wondered if we can add a simple example for tracing the TCP SYN backlog in this repository. What do you think? 