### PR TITLE
dockerfile: build cmd/ and add the binary to CMD instruction

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.travis.yml
+LICENSE
+Makefile
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@ RUN apt-get update && \
     apt-get install -y linux-headers-amd64 && \
     curl -sL https://github.com/cloudflare/ebpf_exporter/files/3890546/libbcc_0.11.0-2_amd64.deb.gz | gunzip > /tmp/libbcc.deb && \
     dpkg -i /tmp/libbcc.deb
-
 COPY ./ /go/ebpf_exporter
 
-RUN cd /go/ebpf_exporter && GOPATH="" GOPROXY="off" GOFLAGS="-mod=vendor" go install -v ./...
+RUN cd /go/ebpf_exporter && \
+    GOPATH="" GOPROXY="off" GOFLAGS="-mod=vendor" go install -v ./... && \
+    cp /root/go/bin/ebpf_exporter /usr/local/bin
+
+CMD ["ebpf_exporter", "--help"]


### PR DESCRIPTION
It would be great to build cmd/ and have it as a CMD instruction.

About CMD:

    https://docs.docker.com/engine/reference/builder/#cmd

Example:

    docker build -t ebpf_exporter .
    docker run ebpf_exporter

---

@bobrik Could you review this PR please?