### PR TITLE
Add machine check events tracing example

### DIFF
--- a/examples/mcevents.yaml
+++ b/examples/mcevents.yaml
@@ -4,26 +4,56 @@ programs:
       counters:
         - name: mc_event_total
           help: Machine check events
-          table: counts
+          table: mc_counts
           labels:
             - name: type
-              size: 8
+              size: 4
               decoders:
+                - name: uint
                 - name: static_map
-                  0: err_corrected
-                  1: err_uncorrected
-                  2: err_deferred
-                  3: err_fatal
-                  4: info
+                  static_map:
+                    0: err_corrected
+                    1: err_uncorrected
+                    2: err_deferred
+                    3: err_fatal
+                    4: info
+            - name: middle_layer
+              size: 1
+              decoders:
+                - name: uint
+            - name: top_layer
+              size: 1
+              decoders:
+                - name: uint
+            - name: mc_index
+              size: 1
+              decoders:
+                - name: uint
+            - name: label
+              size: 101
+              decoders:
+                - name: string
     tracepoints:
       ras:mc_event: tracepoint__ras__mc_event
     code: |
       #include <uapi/linux/ptrace.h>
       #include <linux/types.h>
-      BPF_HASH(counts, u8);
+      struct key_t {
+          uint type;
+          s8 middle_layer;
+          s8 top_layer;
+          s8 mc_index;
+          char label[100];
+      };
+      BPF_HASH(mc_counts, struct key_t, u64);
 
       // Generates function tracepoint__ras__mc_event
       TRACEPOINT_PROBE(ras, mc_event) {
-          counts.increment((uint) args->error_type);
+          struct key_t key = { .type = args->error_type,
+              .middle_layer = args->middle_layer,
+              .top_layer = args->top_layer,
+              .mc_index = args->mc_index};
+          TP_DATA_LOC_READ_CONST(key.label,label,100)
+          mc_counts.increment(key);
           return 0;
       }

--- a/examples/mcevents.yaml
+++ b/examples/mcevents.yaml
@@ -1,5 +1,5 @@
 programs:
-  - name: mcevents 
+  - name: mcevents
     metrics:
       counters:
         - name: mc_event_total
@@ -25,12 +25,24 @@ programs:
               size: 1
               decoders:
                 - name: uint
+            - name: lower_layer
+              size: 1
+              decoders:
+                - name: uint
             - name: mc_index
               size: 1
               decoders:
                 - name: uint
             - name: label
-              size: 101
+              size: 100
+              decoders:
+                - name: string
+            - name: driver_detail
+              size: 30
+              decoders:
+                - name: string
+            - name: msg
+              size: 30
               decoders:
                 - name: string
     tracepoints:
@@ -42,8 +54,11 @@ programs:
           uint type;
           s8 middle_layer;
           s8 top_layer;
+          s8 lower_layer;
           s8 mc_index;
           char label[100];
+          char driver_detail[30];
+          char msg[30];
       };
       BPF_HASH(mc_counts, struct key_t, u64);
 
@@ -52,8 +67,11 @@ programs:
           struct key_t key = { .type = args->error_type,
               .middle_layer = args->middle_layer,
               .top_layer = args->top_layer,
+              .lower_layer = args->lower_layer,
               .mc_index = args->mc_index};
           TP_DATA_LOC_READ_CONST(key.label,label,100)
+          TP_DATA_LOC_READ_CONST(key.driver_detail,driver_detail,30)
+          TP_DATA_LOC_READ_CONST(key.msg,msg,30)
           mc_counts.increment(key);
           return 0;
       }

--- a/examples/mcevents.yaml
+++ b/examples/mcevents.yaml
@@ -1,0 +1,29 @@
+programs:
+  - name: mcevents 
+    metrics:
+      counters:
+        - name: mc_event_total
+          help: Machine check events
+          table: counts
+          labels:
+            - name: type
+              size: 8
+              decoders:
+                - name: static_map
+                  0: err_corrected
+                  1: err_uncorrected
+                  2: err_deferred
+                  3: err_fatal
+                  4: info
+    tracepoints:
+      ras:mc_event: tracepoint__ras__mc_event
+    code: |
+      #include <uapi/linux/ptrace.h>
+      #include <linux/types.h>
+      BPF_HASH(counts, u8);
+
+      // Generates function tracepoint__ras__mc_event
+      TRACEPOINT_PROBE(ras, mc_event) {
+          counts.increment((uint) args->error_type);
+          return 0;
+      }

--- a/examples/mcevents.yaml
+++ b/examples/mcevents.yaml
@@ -37,12 +37,8 @@ programs:
               size: 100
               decoders:
                 - name: string
-            - name: driver_detail
-              size: 30
-              decoders:
-                - name: string
             - name: msg
-              size: 30
+              size: 32
               decoders:
                 - name: string
     tracepoints:
@@ -57,8 +53,7 @@ programs:
           s8 lower_layer;
           s8 mc_index;
           char label[100];
-          char driver_detail[30];
-          char msg[30];
+          char msg[32];
       };
       BPF_HASH(mc_counts, struct key_t, u64);
 
@@ -70,8 +65,7 @@ programs:
               .lower_layer = args->lower_layer,
               .mc_index = args->mc_index};
           TP_DATA_LOC_READ_CONST(key.label,label,100)
-          TP_DATA_LOC_READ_CONST(key.driver_detail,driver_detail,30)
-          TP_DATA_LOC_READ_CONST(key.msg,msg,30)
+          TP_DATA_LOC_READ_CONST(key.msg,msg,32)
           mc_counts.increment(key);
           return 0;
       }


### PR DESCRIPTION
Hi!
This is an example of how EDAC errors might be collected using ebpf-exporter.

It is a stable way to collect such errors, since ```CONFIG_EDAC_LEGACY_SYSFS``` is not set.