### PR TITLE
Add "allow_unknown" option to "static_map" decoder to not add "unknown:" prefix to keys that are not specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,10 +671,24 @@ An example to match `1` to `read` and `2` to `write`:
 - name: operation
   decoders:
     - name:static_map
-      static_decoder_map:
+      static_map:
         1: read
         2: write
 ```
+Unkown keys will be replaced by `"unknown:key_name"` unless `allow_unknown: true`
+is specified in the decoder. For example, the above will decode `3` to `unknown:3`
+and the below example will decode `3` to `3`:
+
+```
+- name: operation
+  decoders:
+    - name:static_map
+      allow_unknown: true
+      static_map:
+        1: read
+        2: write
+```
+
 
 #### `string`
 

--- a/config/config.go
+++ b/config/config.go
@@ -64,9 +64,10 @@ type Label struct {
 
 // Decoder defines how to decode value
 type Decoder struct {
-	Name      string            `yaml:"name"`
-	StaticMap map[string]string `yaml:"static_map"`
-	Regexps   []string          `yaml:"regexps"`
+	Name         string            `yaml:"name"`
+	StaticMap    map[string]string `yaml:"static_map"`
+	Regexps      []string          `yaml:"regexps"`
+	AllowUnknown bool              `yaml:"allow_unknown"`
 }
 
 // HistogramBucketType is an enum to define how to interpret histogram

--- a/decoder/static_map.go
+++ b/decoder/static_map.go
@@ -17,7 +17,11 @@ func (s *StaticMap) Decode(in []byte, conf config.Decoder) ([]byte, error) {
 
 	value, ok := conf.StaticMap[string(in)]
 	if !ok {
-		return []byte(fmt.Sprintf("unknown:%s", in)), nil
+		if !conf.AllowUnknown {
+			return []byte(fmt.Sprintf("unknown:%s", in)), nil
+		} else {
+			return in, nil
+		}
 	}
 
 	return []byte(value), nil

--- a/decoder/static_map.go
+++ b/decoder/static_map.go
@@ -17,11 +17,10 @@ func (s *StaticMap) Decode(in []byte, conf config.Decoder) ([]byte, error) {
 
 	value, ok := conf.StaticMap[string(in)]
 	if !ok {
-		if !conf.AllowUnknown {
-			return []byte(fmt.Sprintf("unknown:%s", in)), nil
-		} else {
+		if conf.AllowUnknown {
 			return in, nil
 		}
+		return []byte(fmt.Sprintf("unknown:%s", in)), nil
 	}
 
 	return []byte(value), nil

--- a/decoder/static_map_test.go
+++ b/decoder/static_map_test.go
@@ -27,7 +27,7 @@ func TestStaticMapDecoder(t *testing.T) {
 		{
 			in:      []byte(strconv.Itoa(int(3))),
 			mapping: map[string]string{"1": "read", "2": "write"},
-            out:     []byte("unknown:3"),
+			out:     []byte("unknown:3"),
 		},
 	}
 
@@ -47,29 +47,29 @@ func TestStaticMapDecoder(t *testing.T) {
 
 func TestStaticMapDecoderAllowUnknown(t *testing.T) {
 	cases := []struct {
-		in      []byte
-		mapping map[string]string
-        allowUnknown bool
-		out     []byte
+		in           []byte
+		mapping      map[string]string
+		allowUnknown bool
+		out          []byte
 	}{
 		{
-			in:      []byte(strconv.Itoa(int(3))),
-			mapping: map[string]string{"1": "read", "2": "write"},
-            allowUnknown: true,
-            out:     []byte("3"),
+			in:           []byte(strconv.Itoa(int(3))),
+			mapping:      map[string]string{"1": "read", "2": "write"},
+			allowUnknown: true,
+			out:          []byte("3"),
 		},
 		{
-			in:      []byte(strconv.Itoa(int(3))),
-			mapping: map[string]string{"1": "read", "2": "write"},
-            allowUnknown: false,
-            out:     []byte("unknown:3"),
+			in:           []byte(strconv.Itoa(int(3))),
+			mapping:      map[string]string{"1": "read", "2": "write"},
+			allowUnknown: false,
+			out:          []byte("unknown:3"),
 		},
 	}
 
 	for _, c := range cases {
 		d := &StaticMap{}
 
-        out, err := d.Decode(c.in, config.Decoder{StaticMap: c.mapping, AllowUnknown: c.allowUnknown})
+		out, err := d.Decode(c.in, config.Decoder{StaticMap: c.mapping, AllowUnknown: c.allowUnknown})
 		if err != nil {
 			t.Errorf("Error decoding %#v with mapping set to %#v: %s", c.in, c.mapping, err)
 		}

--- a/decoder/static_map_test.go
+++ b/decoder/static_map_test.go
@@ -24,12 +24,52 @@ func TestStaticMapDecoder(t *testing.T) {
 			mapping: map[string]string{"1": "read", "2": "write"},
 			out:     []byte("write"),
 		},
+		{
+			in:      []byte(strconv.Itoa(int(3))),
+			mapping: map[string]string{"1": "read", "2": "write"},
+            out:     []byte("unknown:3"),
+		},
 	}
 
 	for _, c := range cases {
 		d := &StaticMap{}
 
 		out, err := d.Decode(c.in, config.Decoder{StaticMap: c.mapping})
+		if err != nil {
+			t.Errorf("Error decoding %#v with mapping set to %#v: %s", c.in, c.mapping, err)
+		}
+
+		if !bytes.Equal(out, c.out) {
+			t.Errorf("Expected %s, got %s", c.out, out)
+		}
+	}
+}
+
+func TestStaticMapDecoderAllowUnknown(t *testing.T) {
+	cases := []struct {
+		in      []byte
+		mapping map[string]string
+        allowUnknown bool
+		out     []byte
+	}{
+		{
+			in:      []byte(strconv.Itoa(int(3))),
+			mapping: map[string]string{"1": "read", "2": "write"},
+            allowUnknown: true,
+            out:     []byte("3"),
+		},
+		{
+			in:      []byte(strconv.Itoa(int(3))),
+			mapping: map[string]string{"1": "read", "2": "write"},
+            allowUnknown: false,
+            out:     []byte("unknown:3"),
+		},
+	}
+
+	for _, c := range cases {
+		d := &StaticMap{}
+
+        out, err := d.Decode(c.in, config.Decoder{StaticMap: c.mapping, AllowUnknown: c.allowUnknown})
 		if err != nil {
 			t.Errorf("Error decoding %#v with mapping set to %#v: %s", c.in, c.mapping, err)
 		}


### PR DESCRIPTION
If this option is true, static_map will not prefix unknown keys with 'unknown:'

The specific use-case is having a ebpf program that adds a "port" label for tcp connections, but "collapses" all ephemeral ports (32768 to 60999) into one value (60999), and then ebpf_exporter changes the label value from 60999 to "ephemeral".