### PR TITLE
gosimple: Fix unnecessary use of fmt.Sprintf

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -331,11 +331,11 @@ func (e *Exporter) TablesHandler(w http.ResponseWriter, r *http.Request) {
 		for name, table := range tables {
 			buf = append(buf, fmt.Sprintf("### Table: %s\n\n", name)...)
 
-			buf = append(buf, fmt.Sprintf("```\n")...)
+			buf = append(buf, "```\n"...)
 			for _, row := range table {
 				buf = append(buf, fmt.Sprintf("%s (%v) -> %f\n", row.raw, row.labels, row.value)...)
 			}
-			buf = append(buf, fmt.Sprintf("```\n\n")...)
+			buf = append(buf, "```\n\n"...)
 		}
 	}
 


### PR DESCRIPTION
Hi @bobrik,

This is a trivial fix for two [gosimple](https://github.com/dominikh/go-tools/tree/master/simple) issues detected running [golangci-lint](https://github.com/golangci/golangci-lint).

See,

```
$ GOPROXY="" golangci-lint run ./...
exporter/exporter.go:334:22: S1039: unnecessary use of fmt.Sprintf (gosimple)
			buf = append(buf, fmt.Sprintf("```\n")...)
			                  ^
exporter/exporter.go:338:22: S1039: unnecessary use of fmt.Sprintf (gosimple)
			buf = append(buf, fmt.Sprintf("```\n\n")...)
```