### PR TITLE
mcevents: fix the size of the fields, add missed semicolons

### DIFF
--- a/examples/mcevents.yaml
+++ b/examples/mcevents.yaml
@@ -34,7 +34,7 @@ programs:
               decoders:
                 - name: uint
             - name: label
-              size: 100
+              size: 32
               decoders:
                 - name: string
             - name: msg
@@ -52,7 +52,7 @@ programs:
           s8 top_layer;
           s8 lower_layer;
           s8 mc_index;
-          char label[100];
+          char label[32];
           char msg[32];
       };
       BPF_HASH(mc_counts, struct key_t, u64);
@@ -64,8 +64,8 @@ programs:
               .top_layer = args->top_layer,
               .lower_layer = args->lower_layer,
               .mc_index = args->mc_index};
-          TP_DATA_LOC_READ_CONST(key.label,label,100)
-          TP_DATA_LOC_READ_CONST(key.msg,msg,32)
+          TP_DATA_LOC_READ_CONST(key.label,label,32);
+          TP_DATA_LOC_READ_CONST(key.msg,msg,32);
           mc_counts.increment(key);
           return 0;
       }

--- a/examples/mcevents.yaml
+++ b/examples/mcevents.yaml
@@ -46,6 +46,7 @@ programs:
     code: |
       #include <uapi/linux/ptrace.h>
       #include <linux/types.h>
+
       struct key_t {
           uint type;
           s8 middle_layer;
@@ -55,17 +56,23 @@ programs:
           char label[32];
           char msg[32];
       };
+
       BPF_HASH(mc_counts, struct key_t, u64);
 
       // Generates function tracepoint__ras__mc_event
       TRACEPOINT_PROBE(ras, mc_event) {
-          struct key_t key = { .type = args->error_type,
+          struct key_t key = {
+              .type = args->error_type,
               .middle_layer = args->middle_layer,
               .top_layer = args->top_layer,
               .lower_layer = args->lower_layer,
-              .mc_index = args->mc_index};
-          TP_DATA_LOC_READ_CONST(key.label,label,32);
-          TP_DATA_LOC_READ_CONST(key.msg,msg,32);
+              .mc_index = args->mc_index,
+          };
+
+          TP_DATA_LOC_READ_CONST(key.label, label, 32);
+          TP_DATA_LOC_READ_CONST(key.msg, msg, 32);
+
           mc_counts.increment(key);
+
           return 0;
       }


### PR DESCRIPTION
Size of the fields msg and label аre mixed up.
Truncate label size to 32((EDAC_MC_LABEL_LEN + 1)), increase MSG size to 64.
Add missed semicolons.