### PR TITLE
upgrade bcc bindings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/alecthomas/units v0.0.0-20201120081800-1786d5ef83d4 // indirect
-	github.com/iovisor/gobpf v0.0.0-20200614202714-e6b321d32103
+	github.com/iovisor/gobpf v0.0.0-20210226085815-9287508f53f6
 	github.com/prometheus/client_golang v1.8.0
 	github.com/prometheus/common v0.15.0
 	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iovisor/gobpf v0.0.0-20200614202714-e6b321d32103 h1:U2+owsfuUe5xehsVEmLZW91zY1ce7z3/YCQjMLVb6Q4=
-github.com/iovisor/gobpf v0.0.0-20200614202714-e6b321d32103/go.mod h1:+5U5qu5UOu8YJ5oHVLvWKH7/Dr5QNHU7mZ2RfPEeXg8=
+github.com/iovisor/gobpf v0.0.0-20210226085815-9287508f53f6 h1:j5juzSOBhGPTEdI9yCG0VM5Dx4Ak26a1cnM0E+xeGCA=
+github.com/iovisor/gobpf v0.0.0-20210226085815-9287508f53f6/go.mod h1:WSY9Jj5RhdgC3ci1QaacvbFdQ8cbrEjrpiZbLHLt2s4=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=

--- a/vendor/github.com/iovisor/gobpf/bcc/module.go
+++ b/vendor/github.com/iovisor/gobpf/bcc/module.go
@@ -258,7 +258,7 @@ func (bpf *Module) attachProbe(evName string, attachType uint32, fnName string, 
 func (bpf *Module) attachUProbe(evName string, attachType uint32, path string, addr uint64, fd, pid int) error {
 	evNameCS := C.CString(evName)
 	binaryPathCS := C.CString(path)
-	res, err := C.bpf_attach_uprobe(C.int(fd), attachType, evNameCS, binaryPathCS, (C.uint64_t)(addr), (C.pid_t)(pid))
+	res, err := C.bpf_attach_uprobe(C.int(fd), attachType, evNameCS, binaryPathCS, (C.uint64_t)(addr), (C.pid_t)(pid), 0)
 	C.free(unsafe.Pointer(evNameCS))
 	C.free(unsafe.Pointer(binaryPathCS))
 

--- a/vendor/github.com/iovisor/gobpf/bcc/perf.go
+++ b/vendor/github.com/iovisor/gobpf/bcc/perf.go
@@ -95,7 +95,7 @@ func rawCallback(cbCookie unsafe.Pointer, raw unsafe.Pointer, rawSize C.int) {
 }
 
 //export lostCallback
-func lostCallback(cbCookie unsafe.Pointer, lost C.ulong) {
+func lostCallback(cbCookie unsafe.Pointer, lost C.uint64_t) {
 	callbackData := lookupCallback(uint64(uintptr(cbCookie)))
 	if callbackData.lostChan != nil {
 		callbackData.lostChan <- uint64(lost)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -14,7 +14,7 @@ github.com/golang/protobuf/ptypes
 github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
-# github.com/iovisor/gobpf v0.0.0-20200614202714-e6b321d32103
+# github.com/iovisor/gobpf v0.0.0-20210226085815-9287508f53f6
 ## explicit
 github.com/iovisor/gobpf/bcc
 github.com/iovisor/gobpf/pkg/cpuonline


### PR DESCRIPTION
Motivation is that the current version no longer works with my kernel (5.4.99).
The dockerfile also needs a bump but I don't know how to update libbcc there.

Fixes https://github.com/cloudflare/ebpf_exporter/issues/92