### PR TITLE
Scan whole /sys/fs/cgroup directory in the cgroup decoder and use a faster filepath.WalkDir function

### DIFF
--- a/decoder/cgroup.go
+++ b/decoder/cgroup.go
@@ -2,8 +2,8 @@ package decoder
 
 import (
 	"fmt"
+	"io/fs"
 	"log"
-	"os"
 	"path/filepath"
 	"strconv"
 
@@ -48,7 +48,7 @@ func (c *CGroup) refreshCache() error {
 
 	cgroupPath := "/sys/fs/cgroup"
 
-	return filepath.Walk(cgroupPath, func(path string, info os.FileInfo, err error) error {
+	return filepath.WalkDir(cgroupPath, func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/decoder/cgroup.go
+++ b/decoder/cgroup.go
@@ -18,7 +18,7 @@ type CGroup struct {
 }
 
 // Decode transforms cgroup id to path in cgroupfs
-func (c *CGroup) Decode(in []byte, conf config.Decoder) ([]byte, error) {
+func (c *CGroup) Decode(in []byte, _ config.Decoder) ([]byte, error) {
 	if c.cache == nil {
 		c.cache = map[uint64][]byte{}
 	}
@@ -46,10 +46,7 @@ func (c *CGroup) Decode(in []byte, conf config.Decoder) ([]byte, error) {
 func (c *CGroup) refreshCache() error {
 	byteOrder := bcc.GetHostByteOrder()
 
-	cgroupPath := "/sys/fs/cgroup/unified"
-	if _, err := os.Stat(cgroupPath); os.IsNotExist(err) {
-		cgroupPath = "/sys/fs/cgroup"
-	}
+	cgroupPath := "/sys/fs/cgroup"
 
 	return filepath.Walk(cgroupPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/decoder/cgroup_test.go
+++ b/decoder/cgroup_test.go
@@ -38,3 +38,15 @@ func TestCgroupDecoder(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkCgroupRefresh(b *testing.B) {
+	d := &CGroup{cache: map[uint64][]byte{}}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		err := d.refreshCache()
+		if err != nil {
+			b.Errorf("Failed to refresh cgroup cache: %s", err)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudflare/ebpf_exporter
 
-go 1.14
+go 1.16
 
 require (
 	github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15 // indirect


### PR DESCRIPTION
1. Scan whole /sys/fs/cgroup directory in the cgroup decoder.
  This resolves a problem when you are using a Hybrid systemd cgroup mode.
  Reference: https://systemd.io/CGROUP_DELEGATION/
2. Use a newer `filepath.WalkDir` function to traverse the cgroup hierarchy. It provides a major speedup to the refresh process.