### PR TITLE
Add an ability to resolve addresses of kernel symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,6 +762,9 @@ perf_events:
 cflags:
   [ - -I/include/path
     - -DMACRO_NAME=value ]
+# Kernel symbol addresses to define as kaddr_{symbol} from /proc/kallsyms (consider CONFIG_KALLSYMS_ALL)
+kaddrs:
+  [ - symbol_to_resolve ]
 # Actual eBPF program code to inject in the kernel
 code: [ code ]
 ```

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type Program struct {
 	PerfEvents     []PerfEvent       `yaml:"perf_events"`
 	Code           string            `yaml:"code"`
 	Cflags         []string          `yaml:"cflags"`
+	Kaddrs         []string          `yaml:"kaddrs"`
 }
 
 // PerfEvent describes perf_event to attach to

--- a/examples/bpf-jit.yaml
+++ b/examples/bpf-jit.yaml
@@ -1,0 +1,44 @@
+programs:
+  - name: bpf-jit
+    metrics:
+      counters:
+        # Technically this is a gauge, but ebpf_exporter only knows counters
+        - name: bpf_jit_pages_currently_allocated
+          help: Current number of pages allocated for bpf jit
+          table: current
+          labels:
+            # ebpf_exporter doesn't support metrics without labels
+            - name: empty
+              size: 8
+              decoders:
+                - name: uint
+                - name: static_map
+                  static_map:
+                    0: ""
+    kprobes:
+      # Sometimes bpf_jit_charge_modmem / bpf_jit_uncharge_modmem get elided,
+      # so we're tracing the outer entrypoints instead.
+      # It's common to see calls to bpf_jit_binary_free not being traced too.
+      bpf_jit_binary_alloc: trace_change
+    kaddrs:
+      # Define kaddr_bpf_jit_current the the address of bpf_jit_current
+      - bpf_jit_current
+    code: |
+      #include <uapi/linux/ptrace.h>
+
+      BPF_HASH(current, u64, u64, 1);
+
+      static int trace_current() {
+          u64 zero = 0, *val;
+
+          s64 bpf_jit_current;
+          bpf_probe_read_kernel(&bpf_jit_current, sizeof(bpf_jit_current), (const void*) kaddr_bpf_jit_current);
+
+          current.update(&zero, &bpf_jit_current);
+
+          return 0;
+      }
+
+      int trace_change(struct pt_regs *ctx, u32 pages) {
+          return trace_current();
+      }


### PR DESCRIPTION
This is convenient if you want to read the value of some global variable from the data section. Note that you need `CONFIG_KALLSYMS_ALL` to make us of it.

Removing unused `ksyms` member of `Exporter` as well.