### PR TITLE
Run linter on Go 1.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: ^1.16
+          go-version: ^1.17
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
The build already runs on Go 1.17.