### PR TITLE
Register build info in prometheus

### DIFF
--- a/cmd/ebpf_exporter/main.go
+++ b/cmd/ebpf_exporter/main.go
@@ -41,6 +41,11 @@ func main() {
 
 	log.Printf("Starting with %d programs found in the config", len(config.Programs))
 
+	err = prometheus.Register(version.NewCollector("ebpf_exporter"))
+	if err != nil {
+		log.Fatalf("Error registering version collector: %s", err)
+	}
+
 	err = prometheus.Register(e)
 	if err != nil {
 		log.Fatalf("Error registering exporter: %s", err)


### PR DESCRIPTION
In `--version` output:

```
ebpf_exporter, version v1.2.4-7-g9e636c8 (branch: master, revision: 9e636c8)
  build user:       docker@e2a4483ac948
  build date:       2021-10-19T01:59:32+00:00
  go version:       go1.17.2
  platform:         linux/arm64
```

As a metric:

```
ebpf_exporter_build_info{branch="master",goversion="go1.17.2",revision="9e636c8",version="v1.2.4-7-g9e636c8"}
```