### PR TITLE
Remove default config path to make `--version` work

### DIFF
--- a/cmd/ebpf_exporter/main.go
+++ b/cmd/ebpf_exporter/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 func main() {
-	configFile := kingpin.Flag("config.file", "Config file path").Default("config.yaml").File()
+	configFile := kingpin.Flag("config.file", "Config file path").File()
 	debug := kingpin.Flag("debug", "Enable debug").Bool()
 	listenAddress := kingpin.Flag("web.listen-address", "The address to listen on for HTTP requests").Default(":9435").String()
 	metricsPath := kingpin.Flag("web.telemetry-path", "Path under which to expose metrics").Default("/metrics").String()


### PR DESCRIPTION
There's no good default config path anyway, and we hit the following issue:

* https://github.com/alecthomas/kingpin/issues/261

```
$ ebpf_exporter --version
ebpf_exporter: error: open config.yaml: no such file or directory, try --help
```