### PR TITLE
Switch libbpfgo back to upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,8 @@ module github.com/cloudflare/ebpf_exporter
 
 go 1.17
 
-// See: https://github.com/aquasecurity/libbpfgo/pull/258
-replace github.com/aquasecurity/libbpfgo v0.4.2-libbpf-1.0.1 => github.com/bobrik/libbpfgo v0.0.0-20221018021422-cc90cc2229db
-
 require (
-	github.com/aquasecurity/libbpfgo v0.4.2-libbpf-1.0.1
+	github.com/aquasecurity/libbpfgo v0.4.3-libbpf-1.0.1
 	github.com/elastic/go-perf v0.0.0-20191212140718-9c656876f595
 	github.com/iovisor/gobpf v0.2.0
 	github.com/prometheus/client_golang v1.12.2

--- a/go.sum
+++ b/go.sum
@@ -41,12 +41,12 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alecthomas/units v0.0.0-20210912230133-d1bdfacee922 h1:8ypNbf5sd3Sm3cKJ9waOGoQv6dKAFiFty9L6NP1AqJ4=
 github.com/alecthomas/units v0.0.0-20210912230133-d1bdfacee922/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
+github.com/aquasecurity/libbpfgo v0.4.3-libbpf-1.0.1 h1:xDHt+EJM/EJt9BXS2YheZNuynT/QNdraL/LHSSpdOxg=
+github.com/aquasecurity/libbpfgo v0.4.3-libbpf-1.0.1/go.mod h1:v+Nk+v6BtHLfdT4kVdsp+fYt4AeUa3cIG2P0y+nBuuY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bobrik/libbpfgo v0.0.0-20221018021422-cc90cc2229db h1:iYa38BA4rJE+2lkcuApCk7iQ7cfFzUw2GivtGtoq0gA=
-github.com/bobrik/libbpfgo v0.0.0-20221018021422-cc90cc2229db/go.mod h1:v+Nk+v6BtHLfdT4kVdsp+fYt4AeUa3cIG2P0y+nBuuY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=

--- a/vendor/github.com/aquasecurity/libbpfgo/libbpfgo.h
+++ b/vendor/github.com/aquasecurity/libbpfgo/libbpfgo.h
@@ -86,11 +86,11 @@ struct perf_buffer *init_perf_buf(int map_fd, int page_cnt, uintptr_t ctx) {
   return pb;
 }
 
-void get_init_value(struct bpf_map *map, void *value) {
-    size_t psize;
-    const void *data;
-    data = bpf_map__initial_value(map, &psize);
-    memcpy(value, data, psize);
+void get_internal_map_init_value(struct bpf_map *map, void *value) {
+  size_t psize;
+  const void *data;
+  data = bpf_map__initial_value(map, &psize);
+  memcpy(value, data, psize);
 }
 
 int bpf_prog_attach_cgroup_legacy(

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -5,7 +5,7 @@ github.com/alecthomas/template/parse
 # github.com/alecthomas/units v0.0.0-20210912230133-d1bdfacee922
 ## explicit; go 1.15
 github.com/alecthomas/units
-# github.com/aquasecurity/libbpfgo v0.4.2-libbpf-1.0.1 => github.com/bobrik/libbpfgo v0.0.0-20221018021422-cc90cc2229db
+# github.com/aquasecurity/libbpfgo v0.4.3-libbpf-1.0.1
 ## explicit; go 1.18
 github.com/aquasecurity/libbpfgo
 # github.com/beorn7/perks v1.0.1


### PR DESCRIPTION
We needed https://github.com/aquasecurity/libbpfgo/pull/258 and it's there now.