### PR TITLE
Register custom handler for perf_event section

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,28 +601,10 @@ See [Programs](#programs) section for more details.
 name: <program name>
 # Metrics attached to the program
 [ metrics: metrics ]
-# Perf events configuration
-perf_events:
-  [ - perf_event ]
 # Kernel symbol addresses to define as kaddr_{symbol} from /proc/kallsyms (consider CONFIG_KALLSYMS_ALL)
 kaddrs:
   [ - symbol_to_resolve ]
 ```
-
-#### `perf_event`
-
-See [llcstat](examples/llcstat.yaml) as an example.
-
-```
-- type: [ perf event type code ]
-  name: [ perf event name code ]
-  target: [ target eBPF function ]
-  sample_period: [ sample period ]
-  sample_frequency: [ sample frequency ]
-```
-
-It's preferred to use `sample_frequency` to let kernel pick the sample period
-automatically, otherwise you may end up with invalid metrics on overflow.
 
 #### `metrics`
 

--- a/examples/llcstat.bpf.c
+++ b/examples/llcstat.bpf.c
@@ -26,13 +26,13 @@ static int trace_event(void *map, u32 cpu, u64 sample_period)
 	return 0;
 }
 
-SEC("perf_event")
+SEC("perf_event/type=0,config=3,frequency=99")
 int on_cache_miss(struct bpf_perf_event_data *ctx)
 {
     return trace_event(&llc_misses_total, bpf_get_smp_processor_id(), ctx->sample_period);
 }
 
-SEC("perf_event")
+SEC("perf_event/type=0,config=2,frequency=99")
 int on_cache_reference(struct bpf_perf_event_data *ctx)
 {
     return trace_event(&llc_references_total, bpf_get_smp_processor_id(), ctx->sample_period);

--- a/examples/llcstat.yaml
+++ b/examples/llcstat.yaml
@@ -19,12 +19,3 @@ programs:
               size: 4
               decoders:
                 - name: uint
-    perf_events:
-      - type: 0x0 # HARDWARE
-        name: 0x3 # PERF_COUNT_HW_CACHE_MISSES
-        target: on_cache_miss
-        sample_frequency: 99
-      - type: 0x0 # HARDWARE
-        name: 0x2 # PERF_COUNT_HW_CACHE_REFERENCES
-        target: on_cache_reference
-        sample_frequency: 99

--- a/exporter/attach.go
+++ b/exporter/attach.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/aquasecurity/libbpfgo"
 	"github.com/cloudflare/ebpf_exporter/config"
-	"github.com/elastic/go-perf"
-	"github.com/iovisor/gobpf/pkg/cpuonline"
 )
 
 const progTagPrefix = "prog_tag:\t"
@@ -23,11 +21,6 @@ func attachModule(module *libbpfgo.Module, program config.Program) (map[string]s
 		prog := iter.NextProgram()
 		if prog == nil {
 			break
-		}
-
-		// We attach perf events separately
-		if prog.GetType() == libbpfgo.BPFProgTypePerfEvent {
-			continue
 		}
 
 		name := prog.Name()
@@ -43,70 +36,6 @@ func attachModule(module *libbpfgo.Module, program config.Program) (map[string]s
 		if err != nil {
 			return nil, fmt.Errorf("failed to attach program %q: %v", name, err)
 		}
-	}
-
-	perfEventProgramTags, err := attachPerfEvents(module, program)
-	if err != nil {
-		return nil, fmt.Errorf("failed to attach perf event tags: %v", err)
-	}
-
-	for key, value := range perfEventProgramTags {
-		tags[key] = value
-	}
-
-	return tags, nil
-}
-
-func attachPerfEvents(module *libbpfgo.Module, program config.Program) (map[string]string, error) {
-	tags := map[string]string{}
-
-	for _, perfEventConfig := range program.PerfEvents {
-		prog, err := module.GetProgram(perfEventConfig.Target)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load target %q in program %q: %s", perfEventConfig.Target, program.Name, err)
-		}
-
-		fa := &perf.Attr{
-			Type:   perf.EventType(perfEventConfig.Type),
-			Config: perfEventConfig.Name,
-		}
-
-		if perfEventConfig.SampleFrequency != 0 {
-			fa.SetSampleFreq(perfEventConfig.SampleFrequency)
-		} else {
-			fa.SetSamplePeriod(perfEventConfig.SamplePeriod)
-		}
-
-		cpus, err := cpuonline.Get()
-		if err != nil {
-			return nil, fmt.Errorf("failed to determine online cpus: %v", err)
-		}
-
-		name := prog.Name()
-
-		for _, cpu := range cpus {
-			event, err := perf.Open(fa, perf.AllThreads, int(cpu), nil)
-			if err != nil {
-				return nil, fmt.Errorf("failed to open perf_event: %v", err)
-			}
-
-			fd, err := event.FD()
-			if err != nil {
-				return nil, fmt.Errorf("failed to get perf_event fd: %v", err)
-			}
-
-			_, err = prog.AttachPerfEvent(fd)
-			if err != nil {
-				return nil, fmt.Errorf("failed to attach perf event %d:%d to %q in program %q on cpu %d: %s", perfEventConfig.Type, perfEventConfig.Name, perfEventConfig.Target, name, cpu, err)
-			}
-		}
-
-		tag, err := extractTag(prog)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get program tag for for program %q: %v", name, err)
-		}
-
-		tags[name] = tag
 	}
 
 	return tags, nil

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -70,6 +70,11 @@ func New(cfg config.Config) (*Exporter, error) {
 
 // Attach injects eBPF into kernel and attaches necessary kprobes
 func (e *Exporter) Attach(configPath string) error {
+	err := registerHandlers()
+	if err != nil {
+		return fmt.Errorf("error registering libbpf handlers: %v", err)
+	}
+
 	for _, program := range e.config.Programs {
 		if _, ok := e.modules[program.Name]; ok {
 			return fmt.Errorf("multiple programs with name %q", program.Name)

--- a/exporter/perf_event.go
+++ b/exporter/perf_event.go
@@ -1,0 +1,116 @@
+package exporter
+
+/*
+#include <stdlib.h>
+#include <bpf/libbpf.h>
+
+extern int attachPerfEventCallback(const struct bpf_program *prog,
+                                   long cookie,
+                                   struct bpf_link **link);
+*/
+import "C"
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"github.com/aquasecurity/libbpfgo"
+	"github.com/elastic/go-perf"
+	"github.com/iovisor/gobpf/pkg/cpuonline"
+	"golang.org/x/sys/unix"
+)
+
+var libbpf_prog_handlers []int
+
+func registerHandlers() error {
+	if libbpf_prog_handlers != nil {
+		return nil
+	}
+
+	name := C.CString("perf_event/")
+	defer C.free(unsafe.Pointer(name))
+
+	opts := C.struct_libbpf_prog_handler_opts{}
+	opts.sz = C.sizeof_struct_libbpf_prog_handler_opts
+	opts.prog_attach_fn = C.libbpf_prog_attach_fn_t(C.attachPerfEventCallback)
+
+	handler := C.libbpf_register_prog_handler(name, uint32(libbpfgo.BPFProgTypePerfEvent), uint32(libbpfgo.BPFAttachTypePerfEvent), &opts)
+	if handler < 0 {
+		return fmt.Errorf("error registering prog handler: %s", unix.ErrnoName(syscall.Errno(handler)))
+	}
+
+	libbpf_prog_handlers = append(libbpf_prog_handlers, int(handler))
+
+	return nil
+}
+
+func parseSectionConfig(section string) (*perf.Attr, []uint, error) {
+	attr := &perf.Attr{}
+
+	for _, item := range strings.Split(strings.TrimPrefix(section, "perf_event/"), ",") {
+		kv := strings.SplitN(item, "=", 2)
+		if len(kv) != 2 {
+			return nil, nil, fmt.Errorf("invalid perf_event item: %q", item)
+		}
+
+		value, err := strconv.Atoi(kv[1])
+		if err != nil {
+			return nil, nil, fmt.Errorf("error parsing value of item %q as integer: %v", item, err)
+		}
+
+		switch kv[0] {
+		case "type":
+			attr.Type = perf.EventType(value)
+		case "config":
+			attr.Config = uint64(value)
+		case "frequency":
+			attr.SetSampleFreq(uint64(value))
+		default:
+			return nil, nil, fmt.Errorf("unknown perf_event item %q", item)
+		}
+	}
+
+	cpus, err := cpuonline.Get()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to determine online cpus: %v", err)
+	}
+
+	return attr, cpus, nil
+}
+
+func attachPerfEvent(prog *C.struct_bpf_program) ([]*C.struct_bpf_link, error) {
+	section := C.GoString(C.bpf_program__section_name(prog))
+
+	fa, cpus, err := parseSectionConfig(section)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse section %q: %v", section, err)
+	}
+
+	links := make([]*C.struct_bpf_link, len(cpus))
+
+	name := C.GoString(C.bpf_program__name(prog))
+
+	for i, cpu := range cpus {
+		event, err := perf.Open(fa, perf.AllThreads, int(cpu), nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open perf_event: %v", err)
+		}
+
+		fd, err := event.FD()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get perf_event fd: %v", err)
+		}
+
+		link, err := C.bpf_program__attach_perf_event(prog, C.int(fd))
+		if link == nil {
+			return nil, fmt.Errorf("failed to attach perf event %d:%d to program %q on cpu %d: %v", fa.Type, fa.Config, name, cpu, err)
+		}
+
+		links[i] = link
+	}
+
+	return links, nil
+}

--- a/exporter/perf_event_cb.go
+++ b/exporter/perf_event_cb.go
@@ -1,0 +1,27 @@
+package exporter
+
+import "C"
+
+import (
+	"log"
+	"syscall"
+	"unsafe"
+)
+
+// These callbacks need to be in a separate file to avoid multiple definitions error
+
+//export attachPerfEventCallback
+func attachPerfEventCallback(prog unsafe.Pointer, cookie C.long, link *unsafe.Pointer) C.int {
+	program := (*C.struct_bpf_program)(prog)
+
+	links, err := attachPerfEvent(program)
+	if err != nil {
+		log.Printf("Error attaching perf event: %v", err)
+		return C.int(syscall.EINVAL)
+	}
+
+	// Use the first link as we need to return something
+	*link = unsafe.Pointer(&links[0])
+
+	return C.int(0)
+}


### PR DESCRIPTION
This switches over `perf_event` to SEC annotation driven attachment.

```
SEC("perf_event/type=0,config=3,frequency=99")
```