### PR TITLE
Add -Werror to examples and benchmarks

### DIFF
--- a/benchmark/probes/Makefile
+++ b/benchmark/probes/Makefile
@@ -6,7 +6,7 @@ SRC = ${wildcard *.bpf.c}
 OBJ = ${patsubst %.bpf.c, %.bpf.o, $(SRC)}
 
 $(OBJ): %.bpf.o: %.bpf.c
-	$(CC) -g -O2 -Wall -D__TARGET_ARCH_$(ARCH) -I../../include/$(ARCH) -c -target bpf $< -o $@
+	$(CC) -g -O2 -Wall -Werror -D__TARGET_ARCH_$(ARCH) -I../../include/$(ARCH) -c -target bpf $< -o $@
 
 .PHONY: clean
 clean:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -18,7 +18,7 @@ CLANG_BPF_SYS_INCLUDES = $(shell $(CC) -v -E - </dev/null 2>&1 \
 	| sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')
 
 $(OBJ): %.bpf.o: %.bpf.c
-	$(CC) -g -O2 -Wall -D__TARGET_ARCH_$(ARCH) $(CLANG_BPF_SYS_INCLUDES) -I../include/$(ARCH) -c -target bpf $< -o $@
+	$(CC) -g -O2 -Wall -Werror -D__TARGET_ARCH_$(ARCH) $(CLANG_BPF_SYS_INCLUDES) -I../include/$(ARCH) -c -target bpf $< -o $@
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
We want to fail if there are any warnings, as those can then fail at runtime.