### PR TITLE
Update Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,20 @@
-FROM ubuntu:22.04 as builder
+FROM golang:1.19-bullseye as builder
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl git ca-certificates build-essential libelf-dev gnupg2
+    apt-get install -y --no-install-recommends libelf-dev
 
-RUN echo 'deb https://ppa.launchpadcontent.net/longsleep/golang-backports/ubuntu jammy main' > /etc/apt/sources.list.d/golang-backports.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 52b59b1571a79dbc054901c0f6bc817356a3d45e && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends golang-1.19-go
-
-RUN mkdir /build
-
-RUN git clone --branch v1.0.1 --depth 1 https://github.com/libbpf/libbpf.git /build/libbpf && \
-    make -C /build/libbpf/src BUILD_STATIC_ONLY=y LIBSUBDIR=lib install
-
-RUN tar -czf /build/libbpf.tar.gz /usr/lib/libbpf.a /usr/lib/pkgconfig/libbpf.pc /usr/include/bpf
+RUN mkdir /build && \
+    git clone --branch v1.0.1 --depth 1 https://github.com/libbpf/libbpf.git /build/libbpf && \
+    make -j $(nproc) -C /build/libbpf/src BUILD_STATIC_ONLY=y LIBSUBDIR=lib install && \
+    tar -czf /build/libbpf.tar.gz /usr/lib/libbpf.a /usr/lib/pkgconfig/libbpf.pc /usr/include/bpf
 
 COPY ./ /build/ebpf_exporter
 
 RUN cd /build/ebpf_exporter && \
-    PATH="/usr/lib/go-1.19/bin:$PATH" make build && \
+    make build && \
     /build/ebpf_exporter/ebpf_exporter --version
 
-FROM scratch as ebpf_exporter
+FROM gcr.io/distroless/static-debian11 as ebpf_exporter
 
 COPY --from=builder /build/ebpf_exporter/ebpf_exporter /ebpf_exporter
 


### PR DESCRIPTION
Some simplification of the Dockerfile.
* Use official Go build image.
* Consolidate RUN steps to reduce layers.
* Use "distroless" for final image.

Signed-off-by: SuperQ <superq@gmail.com>