### PR TITLE
Enable loose attachment of programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,8 @@ ebpf_exporter_ebpf_programs{function="xfs_fs_nr_cached_objects_end",program="xfs
 ebpf_exporter_ebpf_programs{function="xfs_fs_nr_cached_objects_start",program="xfs_reclaim",tag="cf30348184f983dd"} 1
 ```
 
+If any program failed to attach, it will have a metric value of zero.
+
 Here `tag` can be used for tracing and performance analysis with two conditions:
 
 * `net.core.bpf_jit_kallsyms=1` sysctl is set

--- a/README.md
+++ b/README.md
@@ -678,20 +678,18 @@ This gauge reports a timeseries for every loaded logical program:
 ebpf_exporter_enabled_programs{name="xfs_reclaim"} 1
 ```
 
-### `ebpf_exporter_ebpf_programs`
+### `ebpf_exporter_ebpf_program_info`
 
 This gauge reports information available for every ebpf program:
 
 ```
 # HELP ebpf_exporter_ebpf_programs Info about ebpf programs
 # TYPE ebpf_exporter_ebpf_programs gauge
-ebpf_exporter_ebpf_programs{function="xfs_fs_free_cached_objects_end",program="xfs_reclaim",tag="d5e845dc27b372e4"} 1
-ebpf_exporter_ebpf_programs{function="xfs_fs_free_cached_objects_start",program="xfs_reclaim",tag="c2439d02dd0ba000"} 1
-ebpf_exporter_ebpf_programs{function="xfs_fs_nr_cached_objects_end",program="xfs_reclaim",tag="598375893f34ef39"} 1
-ebpf_exporter_ebpf_programs{function="xfs_fs_nr_cached_objects_start",program="xfs_reclaim",tag="cf30348184f983dd"} 1
+ebpf_exporter_ebpf_program_info{function="add_to_page_cache_lru",id="247",program="cachestat",tag="6c007da3187b5b32"} 1
+ebpf_exporter_ebpf_program_info{function="folio_account_dirtied",id="249",program="cachestat",tag="6c007da3187b5b32"} 1
+ebpf_exporter_ebpf_program_info{function="mark_buffer_dirty",id="250",program="cachestat",tag="6c007da3187b5b32"} 1
+ebpf_exporter_ebpf_program_info{function="mark_page_accessed",id="248",program="cachestat",tag="6c007da3187b5b32"} 1
 ```
-
-If any program failed to attach, it will have a metric value of zero.
 
 Here `tag` can be used for tracing and performance analysis with two conditions:
 
@@ -702,6 +700,58 @@ Newer kernels allow `--kallsyms` to `perf top` as well,
 in the future it may not be required at all:
 
 * https://www.spinics.net/lists/linux-perf-users/msg07216.html
+
+### `ebpf_exporter_ebpf_program_attached`
+
+This gauge reports whether individual programs were successfully attached.
+
+```
+# HELP ebpf_exporter_ebpf_program_attached Whether a program is attached
+# TYPE ebpf_exporter_ebpf_program_attached gauge
+ebpf_exporter_ebpf_program_attached{id="247"} 1
+ebpf_exporter_ebpf_program_attached{id="248"} 1
+ebpf_exporter_ebpf_program_attached{id="249"} 0
+ebpf_exporter_ebpf_program_attached{id="250"} 1
+```
+
+It needs to be joined by `id` label with `ebpf_exporter_ebpf_program_info`
+to get more information about the program.
+
+### `ebpf_exporter_ebpf_program_run_time_seconds`
+
+This counter reports how much time individual programs spent running.
+
+```
+# HELP ebpf_exporter_ebpf_program_run_time_seconds How long has the program been executing
+# TYPE ebpf_exporter_ebpf_program_run_time_seconds counter
+ebpf_exporter_ebpf_program_run_time_seconds{id="247"} 0
+ebpf_exporter_ebpf_program_run_time_seconds{id="248"} 0.001252621
+ebpf_exporter_ebpf_program_run_time_seconds{id="249"} 0
+ebpf_exporter_ebpf_program_run_time_seconds{id="250"} 3.6668e-05
+```
+
+It requires `kernel.bpf_stats_enabled` sysctl to be enabled.
+
+It needs to be joined by `id` label with `ebpf_exporter_ebpf_program_info`
+to get more information about the program.
+
+### `ebpf_exporter_ebpf_program_run_count_total`
+
+This counter reports how many times individual programs ran.
+
+```
+# HELP ebpf_exporter_ebpf_program_run_count_total How many times has the program been executed
+# TYPE ebpf_exporter_ebpf_program_run_count_total counter
+ebpf_exporter_ebpf_program_run_count_total{id="247"} 0
+ebpf_exporter_ebpf_program_run_count_total{id="248"} 11336
+ebpf_exporter_ebpf_program_run_count_total{id="249"} 0
+ebpf_exporter_ebpf_program_run_count_total{id="250"} 69
+```
+
+It requires `kernel.bpf_stats_enabled` sysctl to be enabled.
+
+It needs to be joined by `id` label with `ebpf_exporter_ebpf_program_info`
+to get more information about the program.
 
 ## License
 

--- a/exporter/attach.go
+++ b/exporter/attach.go
@@ -1,21 +1,14 @@
 package exporter
 
 import (
-	"bufio"
-	"errors"
-	"fmt"
 	"log"
-	"os"
-	"strings"
 
 	"github.com/aquasecurity/libbpfgo"
 	"github.com/cloudflare/ebpf_exporter/config"
 )
 
-const progTagPrefix = "prog_tag:\t"
-
-func attachModule(module *libbpfgo.Module, program config.Program) ([]progAttachment, error) {
-	attachments := []progAttachment{}
+func attachModule(module *libbpfgo.Module, program config.Program) (map[*libbpfgo.BPFProg]bool, error) {
+	attached := map[*libbpfgo.BPFProg]bool{}
 
 	iter := module.Iterator()
 	for {
@@ -24,59 +17,14 @@ func attachModule(module *libbpfgo.Module, program config.Program) ([]progAttach
 			break
 		}
 
-		name := prog.Name()
-
-		tag, err := extractTag(prog)
+		_, err := prog.AttachGeneric()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get program tag for for program %q: %v", name, err)
-		}
-
-		attachment := progAttachment{
-			name: name,
-			tag:  tag,
-		}
-
-		_, err = prog.AttachGeneric()
-		if err != nil {
-			log.Printf("Failed to attach program %q for %q: %v", name, program.Name, err)
+			log.Printf("Failed to attach program %q for %q: %v", prog.Name(), program.Name, err)
+			attached[prog] = false
 		} else {
-			attachment.attached = true
-		}
-
-		attachments = append(attachments, attachment)
-	}
-
-	return attachments, nil
-}
-
-func extractTag(prog *libbpfgo.BPFProg) (string, error) {
-	name := fmt.Sprintf("/proc/self/fdinfo/%d", prog.FileDescriptor())
-
-	file, err := os.Open(name)
-	if err != nil {
-		return "", fmt.Errorf("can't open %s: %v", name, err)
-	}
-
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, progTagPrefix) {
-			return strings.TrimPrefix(line, progTagPrefix), nil
+			attached[prog] = true
 		}
 	}
 
-	if err = scanner.Err(); err != nil {
-		return "", fmt.Errorf("error scanning: %v", err)
-	}
-
-	return "", errors.New("cannot find program tag")
-}
-
-type progAttachment struct {
-	name     string
-	tag      string
-	attached bool
+	return attached, nil
 }

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -250,8 +250,16 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 			}
 
 			ch <- prometheus.MustNewConstMetric(e.programAttachedDesc, prometheus.GaugeValue, attachedValue, id)
-			ch <- prometheus.MustNewConstMetric(e.programRunTimeDesc, prometheus.CounterValue, info.runTime.Seconds(), id)
-			ch <- prometheus.MustNewConstMetric(e.programRunCountDesc, prometheus.CounterValue, float64(info.runCount), id)
+
+			statsEnabled, err := bpfStatsEnabled()
+			if err != nil {
+				log.Printf("Error checking whether bpf stats are enabled: %v", err)
+			} else {
+				if statsEnabled {
+					ch <- prometheus.MustNewConstMetric(e.programRunTimeDesc, prometheus.CounterValue, info.runTime.Seconds(), id)
+					ch <- prometheus.MustNewConstMetric(e.programRunCountDesc, prometheus.CounterValue, float64(info.runCount), id)
+				}
+			}
 		}
 	}
 

--- a/exporter/prog_info.go
+++ b/exporter/prog_info.go
@@ -1,0 +1,65 @@
+package exporter
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aquasecurity/libbpfgo"
+)
+
+type progInfo struct {
+	id       int
+	tag      string
+	runTime  time.Duration
+	runCount int
+}
+
+func extractProgInfo(prog *libbpfgo.BPFProg) (progInfo, error) {
+	info := progInfo{}
+
+	name := fmt.Sprintf("/proc/self/fdinfo/%d", prog.FileDescriptor())
+
+	file, err := os.Open(name)
+	if err != nil {
+		return info, fmt.Errorf("can't open %s: %v", name, err)
+	}
+
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+
+		switch fields[0] {
+		case "prog_tag:":
+			info.tag = fields[1]
+		case "prog_id:":
+			info.id, err = strconv.Atoi(fields[1])
+			if err != nil {
+				return info, fmt.Errorf("error parsing prog id %q as int: %v", fields[1], err)
+			}
+		case "run_time_ns:":
+			runTimeNs, err := strconv.Atoi(fields[1])
+			if err != nil {
+				return info, fmt.Errorf("error parsing prog run time duration %q as int: %v", fields[1], err)
+			}
+			info.runTime = time.Nanosecond * time.Duration(runTimeNs)
+		case "run_cnt:":
+			info.runCount, err = strconv.Atoi(fields[1])
+			if err != nil {
+				return info, fmt.Errorf("error parsing prog run count %q as int: %v", fields[1], err)
+			}
+		}
+	}
+
+	if err = scanner.Err(); err != nil {
+		return info, fmt.Errorf("error scanning: %v", err)
+	}
+
+	return info, nil
+}


### PR DESCRIPTION
Now that we're using libbpf to drive attachment configuration from bpf code itself, it's no longer an option to only attach some of the programs.

In cases like cachestat where some functions might not be available for tracing, this is a bit annoying to work around.

Previously if you had a missing attach target, we would've just failed to start:

```
2022/10/23 16:44:21 Error attaching exporter: failed to attach to program "cachestat": failed to attach program "folio_account_dirtied": failed to attach program: no such file or directory
```

With the new code you would get a log line at startup:

```
2022/10/23 16:42:37 Failed to attach program "folio_account_dirtied" for "cachestat": failed to attach program: no such file or directory
```

And there would be an indication in metrics, allowing you to alert:

```
ebpf_exporter_ebpf_programs{function="add_to_page_cache_lru",program="cachestat",tag="6c007da3187b5b32"} 1
ebpf_exporter_ebpf_programs{function="folio_account_dirtied",program="cachestat",tag="6c007da3187b5b32"} 0
ebpf_exporter_ebpf_programs{function="mark_buffer_dirty",program="cachestat",tag="6c007da3187b5b32"} 1
ebpf_exporter_ebpf_programs{function="mark_page_accessed",program="cachestat",tag="6c007da3187b5b32"} 1
```

This might work fine for some programs, but not so well for others. Having an ability to alert makes it universally usable.

There's an option to add a flag to control this, we might do it later if there's any real world need for that.