### PR TITLE
Upgrade github actions to latest to resolve warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,9 @@ jobs:
     name: Build ebpf_exporter (x86_64)
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-
-      # Tags are needed for the build version. See:
-      # * https://github.com/actions/checkout/issues/206
-      - name: Fetch full git history
-        run: git fetch --prune --unshallow --tags --force
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Fetch with tags to have the build version attached
 
       - name: Build libbpf and ebpf_exporter
         run: |
@@ -47,12 +44,9 @@ jobs:
         with:
           targets: aarch64
 
-      - uses: actions/checkout@v2
-
-      # Tags are needed for the build version. See:
-      # * https://github.com/actions/checkout/issues/206
-      - name: Fetch full git history
-        run: git fetch --prune --unshallow --tags --force
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Fetch with tags to have the build version attached
 
       - name: Build ebpf_exporter
         run: |
@@ -82,7 +76,7 @@ jobs:
         with:
           go-version: ^1.19
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download libbpf.tar.gz
         uses: actions/download-artifact@v2
@@ -110,7 +104,7 @@ jobs:
         with:
           go-version: ^1.19
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download libbpf.tar.gz
         uses: actions/download-artifact@v2
@@ -138,7 +132,7 @@ jobs:
     needs: build-ebpf-exporter-x86_64
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download libbpf.tar.gz
         uses: actions/download-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,13 @@ jobs:
           docker cp $id:/build/libbpf.tar.gz                libbpf.x86_64.tar.gz
 
       - name: Upload libbpf.tar.gz
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: libbpf.x86_64.tar.gz
           path: libbpf.x86_64.tar.gz
 
       - name: Upload ebpf_exporter
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ebpf_exporter.x86_64
           path: ebpf_exporter.x86_64
@@ -56,13 +56,13 @@ jobs:
           docker cp $id:/build/libbpf.tar.gz                libbpf.aarch64.tar.gz
 
       - name: Upload libbpf.tar.gz
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: libbpf.aarch64.tar.gz
           path: libbpf.aarch64.tar.gz
 
       - name: Upload ebpf_exporter
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ebpf_exporter.aarch64
           path: ebpf_exporter.aarch64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download libbpf.tar.gz
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: libbpf.x86_64.tar.gz
 
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download libbpf.tar.gz
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: libbpf.x86_64.tar.gz
 
@@ -135,7 +135,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download libbpf.tar.gz
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: libbpf.x86_64.tar.gz
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     needs: build-ebpf-exporter-x86_64
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ^1.19
 
@@ -100,7 +100,7 @@ jobs:
     needs: build-ebpf-exporter-x86_64
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ^1.19
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
         run: go mod verify
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50.0
         env:


### PR DESCRIPTION
There are warnings like this:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/upload-artifact, actions/upload-artifact, actions/checkoutShow less

In here: https://github.com/cloudflare/ebpf_exporter/actions/runs/3325582197