### PR TITLE
Update module path to adhere with Go versioning guidelines

### DIFF
--- a/benchmark/getpid_test.go
+++ b/benchmark/getpid_test.go
@@ -7,7 +7,7 @@ import (
 	"unsafe"
 
 	"github.com/aquasecurity/libbpfgo"
-	"github.com/cloudflare/ebpf_exporter/util"
+	"github.com/cloudflare/ebpf_exporter/v2/util"
 )
 
 func BenchmarkGetpidWithoutAnyProbes(b *testing.B) {

--- a/cmd/ebpf_exporter/main.go
+++ b/cmd/ebpf_exporter/main.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cloudflare/ebpf_exporter/config"
-	"github.com/cloudflare/ebpf_exporter/exporter"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
+	"github.com/cloudflare/ebpf_exporter/v2/exporter"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/version"

--- a/decoder/cgroup.go
+++ b/decoder/cgroup.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/cloudflare/ebpf_exporter/config"
-	"github.com/cloudflare/ebpf_exporter/util"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
+	"github.com/cloudflare/ebpf_exporter/v2/util"
 	"golang.org/x/sys/unix"
 )
 

--- a/decoder/cgroup_test.go
+++ b/decoder/cgroup_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/cloudflare/ebpf_exporter/config"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
 )
 
 func TestCgroupDecoder(t *testing.T) {

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/cloudflare/ebpf_exporter/config"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
 )
 
 // ErrSkipLabelSet instructs exporter to skip label set

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/cloudflare/ebpf_exporter/config"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
 )
 
 func TestDecodeLabels(t *testing.T) {

--- a/decoder/dname.go
+++ b/decoder/dname.go
@@ -1,7 +1,7 @@
 package decoder
 
 import (
-	"github.com/cloudflare/ebpf_exporter/config"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
 )
 
 // Dname is a decoder that decodes DNS qname wire format

--- a/decoder/dname_test.go
+++ b/decoder/dname_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/cloudflare/ebpf_exporter/config"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
 )
 
 func TestDnameDecoder(t *testing.T) {

--- a/decoder/inet_ip.go
+++ b/decoder/inet_ip.go
@@ -3,7 +3,7 @@ package decoder
 import (
 	"net"
 
-	"github.com/cloudflare/ebpf_exporter/config"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
 )
 
 // InetIP is a decoder that transforms an ip byte representation into a string

--- a/decoder/inet_ip_test.go
+++ b/decoder/inet_ip_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/cloudflare/ebpf_exporter/config"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
 )
 
 func TestInetIpDecoder(t *testing.T) {

--- a/decoder/ksym.go
+++ b/decoder/ksym.go
@@ -3,8 +3,8 @@ package decoder
 import (
 	"fmt"
 
-	"github.com/cloudflare/ebpf_exporter/config"
-	"github.com/cloudflare/ebpf_exporter/util"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
+	"github.com/cloudflare/ebpf_exporter/v2/util"
 	"github.com/iovisor/gobpf/pkg/ksym"
 )
 

--- a/decoder/ksym_test.go
+++ b/decoder/ksym_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/cloudflare/ebpf_exporter/config"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
 )
 
 func TestKsymDecoder(t *testing.T) {

--- a/decoder/majorminor.go
+++ b/decoder/majorminor.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cloudflare/ebpf_exporter/config"
-	"github.com/cloudflare/ebpf_exporter/util"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
+	"github.com/cloudflare/ebpf_exporter/v2/util"
 	"golang.org/x/sys/unix"
 )
 

--- a/decoder/majorminor_test.go
+++ b/decoder/majorminor_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/cloudflare/ebpf_exporter/config"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
 )
 
 func TestMajorMinorDecoder(t *testing.T) {

--- a/decoder/regexp.go
+++ b/decoder/regexp.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/cloudflare/ebpf_exporter/config"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
 )
 
 // Regexp is a decoder that only allows inputs matching regexp

--- a/decoder/regexp_test.go
+++ b/decoder/regexp_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/cloudflare/ebpf_exporter/config"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
 )
 
 func TestRegexpDecoder(t *testing.T) {

--- a/decoder/static_map.go
+++ b/decoder/static_map.go
@@ -3,7 +3,7 @@ package decoder
 import (
 	"fmt"
 
-	"github.com/cloudflare/ebpf_exporter/config"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
 )
 
 // StaticMap is a decoded that maps values according to a static map

--- a/decoder/static_map_test.go
+++ b/decoder/static_map_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/cloudflare/ebpf_exporter/config"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
 )
 
 func TestStaticMapDecoder(t *testing.T) {

--- a/decoder/string.go
+++ b/decoder/string.go
@@ -1,7 +1,7 @@
 package decoder
 
 import (
-	"github.com/cloudflare/ebpf_exporter/config"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
 )
 
 // String is a decoder that decodes strings coming from the kernel

--- a/decoder/string_test.go
+++ b/decoder/string_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/cloudflare/ebpf_exporter/config"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
 )
 
 func TestStringDecoder(t *testing.T) {

--- a/decoder/uint.go
+++ b/decoder/uint.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/cloudflare/ebpf_exporter/config"
-	"github.com/cloudflare/ebpf_exporter/util"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
+	"github.com/cloudflare/ebpf_exporter/v2/util"
 )
 
 // UInt is a decoder that transforms unsigned integers into their string values

--- a/decoder/uint_test.go
+++ b/decoder/uint_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/cloudflare/ebpf_exporter/config"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
 )
 
 func TestUIntDecoder(t *testing.T) {

--- a/exporter/attach.go
+++ b/exporter/attach.go
@@ -4,7 +4,7 @@ import (
 	"log"
 
 	"github.com/aquasecurity/libbpfgo"
-	"github.com/cloudflare/ebpf_exporter/config"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
 )
 
 func attachModule(module *libbpfgo.Module, cfg config.Config) (map[*libbpfgo.BPFProg]bool, error) {

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -11,9 +11,9 @@ import (
 	"unsafe"
 
 	"github.com/aquasecurity/libbpfgo"
-	"github.com/cloudflare/ebpf_exporter/config"
-	"github.com/cloudflare/ebpf_exporter/decoder"
-	"github.com/cloudflare/ebpf_exporter/util"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
+	"github.com/cloudflare/ebpf_exporter/v2/decoder"
+	"github.com/cloudflare/ebpf_exporter/v2/util"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/exporter/histogram.go
+++ b/exporter/histogram.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/cloudflare/ebpf_exporter/config"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
 )
 
 type histogramWithLabels struct {

--- a/exporter/perf_event_array.go
+++ b/exporter/perf_event_array.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/aquasecurity/libbpfgo"
-	"github.com/cloudflare/ebpf_exporter/config"
-	"github.com/cloudflare/ebpf_exporter/decoder"
+	"github.com/cloudflare/ebpf_exporter/v2/config"
+	"github.com/cloudflare/ebpf_exporter/v2/decoder"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cloudflare/ebpf_exporter
+module github.com/cloudflare/ebpf_exporter/v2
 
 go 1.17
 


### PR DESCRIPTION
Signed-off-by: Aditya Sharma <aditya.sharma@shopify.com>

## Context

When trying to install/import `ebpf_exporter@v2.0.0` as a Go dependency, the toolchain throws the following error.

```
go install github.com/cloudflare/ebpf_exporter/cmd/ebpf_exporter@v2.0.0
go: github.com/cloudflare/ebpf_exporter/cmd/ebpf_exporter@v2.0.0: github.com/cloudflare/ebpf_exporter@v2.0.0: invalid version: module contains a go.mod file, so module path must match major version ("github.com/cloudflare/ebpf_exporter/v2")
```
OR
```
go get github.com/cloudflare/ebpf_exporter@v2.0.0
go: github.com/cloudflare/ebpf_exporter@v2.0.0: invalid version: module contains a go.mod file, so module path must match major version ("github.com/cloudflare/ebpf_exporter/v2")
```

## Fix

Updated the module paths to include `/v2` by using https://github.com/icholy/gomajor:
```bash
gomajor path -next
```


cc @bobrik 


