### PR TITLE
code clean for config define HistogramBucketType

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -75,11 +75,11 @@ type HistogramBucketType string
 
 const (
 	// HistogramBucketExp2 means histograms with power-of-two keys
-	HistogramBucketExp2 = "exp2"
+	HistogramBucketExp2 HistogramBucketType = "exp2"
 	// HistogramBucketLinear means histogram with linear keys
-	HistogramBucketLinear = "linear"
+	HistogramBucketLinear HistogramBucketType = "linear"
 	// HistogramBucketFixed means histogram with fixed user-defined keys
-	HistogramBucketFixed = "fixed"
+	HistogramBucketFixed HistogramBucketType = "fixed"
 )
 
 func ParseConfigs(dir string, names []string) ([]Config, error) {


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

Make code more readable.
```
// HistogramBucketType is an enum to define how to interpret histogram
type HistogramBucketType string

const (
	// HistogramBucketExp2 means histograms with power-of-two keys
	HistogramBucketExp2 HistogramBucketType = "exp2"
	// HistogramBucketLinear means histogram with linear keys
	HistogramBucketLinear HistogramBucketType = "linear"
	// HistogramBucketFixed means histogram with fixed user-defined keys
	HistogramBucketFixed HistogramBucketType = "fixed"
)
```
