### PR TITLE
Pre-aggregate label sets to allow duplicate labels

### DIFF
--- a/decoder/cgroup.go
+++ b/decoder/cgroup.go
@@ -40,7 +40,10 @@ func (c *CGroup) Decode(in []byte, _ config.Decoder) ([]byte, error) {
 		return path, nil
 	}
 
-	return []byte(fmt.Sprintf("unknown_cgroup_id:%d", cgroupID)), nil
+	name := []byte(fmt.Sprintf("unknown_cgroup_id:%d", cgroupID))
+	c.cache[uint64(cgroupID)] = name
+
+	return name, nil
 }
 
 func (c *CGroup) refreshCache() error {

--- a/examples/cgroup.bpf.c
+++ b/examples/cgroup.bpf.c
@@ -4,7 +4,7 @@
 #include "maps.bpf.h"
 
 struct {
-    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
     __uint(max_entries, 1024);
     __type(key, u64);
     __type(value, u64);

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -1,0 +1,45 @@
+package exporter
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestAggregatedMetricValues(t *testing.T) {
+	values := []metricValue{
+		{
+			labels: []string{"foo"},
+			value:  8,
+		},
+		{
+			labels: []string{"bar"},
+			value:  1,
+		},
+		{
+			labels: []string{"foo"},
+			value:  3,
+		},
+	}
+
+	aggregated := aggregateMapValues(values)
+
+	sort.Slice(aggregated, func(i, j int) bool {
+		return aggregated[i].value > aggregated[j].value
+	})
+
+	expected := []aggregatedMetricValue{
+		{
+			labels: []string{"foo"},
+			value:  11,
+		},
+		{
+			labels: []string{"bar"},
+			value:  1,
+		},
+	}
+
+	if !reflect.DeepEqual(aggregated, expected) {
+		t.Errorf("expected after aggregation: %#v, got: %#v", expected, aggregated)
+	}
+}


### PR DESCRIPTION
When systemd restarts a service, it makes a fresh cgroup:

* https://github.com/systemd/systemd/issues/26101

For metrics that use `bpf_get_current_cgroup_id()` with a `cgroup` decoder in a label that means that two different IDs would map to the same cgroup name. As a result, prometheus is unhappy that two timeseries have the same set of labels, breaking the exporter.

Let's pre-aggregate metrics to collapse these into the same label set by summing up the values. In the cgroup example above we end up with just one unique set of labels per service, encompassing events across restarts.

This assumes that all exported values are counters or do not have conflicts as described above.

Let's also switch bpf map type for cgroup example to LRU hash, to account for cgroup id churn, as we don't want to hit the map size limit over time.