### PR TITLE
Use bpf instruction set v3

### DIFF
--- a/benchmark/probes/Makefile
+++ b/benchmark/probes/Makefile
@@ -6,7 +6,7 @@ SRC = ${wildcard *.bpf.c}
 OBJ = ${patsubst %.bpf.c, %.bpf.o, $(SRC)}
 
 $(OBJ): %.bpf.o: %.bpf.c
-	$(CC) -g -O2 -Wall -Werror -D__TARGET_ARCH_$(ARCH) -I../../include/$(ARCH) -c -target bpf $< -o $@
+	$(CC) -mcpu=v3 -g -O2 -Wall -Werror -D__TARGET_ARCH_$(ARCH) -I../../include/$(ARCH) -c -target bpf $< -o $@
 
 .PHONY: clean
 clean:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -18,7 +18,7 @@ CLANG_BPF_SYS_INCLUDES = $(shell $(CC) -v -E - </dev/null 2>&1 \
 	| sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')
 
 $(OBJ): %.bpf.o: %.bpf.c
-	$(CC) -g -O2 -Wall -Werror -D__TARGET_ARCH_$(ARCH) $(CFLAGS) $(CLANG_BPF_SYS_INCLUDES) -I../include/$(ARCH) -c -target bpf $< -o $@
+	$(CC) -mcpu=v3 -g -O2 -Wall -Werror -D__TARGET_ARCH_$(ARCH) $(CFLAGS) $(CLANG_BPF_SYS_INCLUDES) -I../include/$(ARCH) -c -target bpf $< -o $@
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
See: https://pchaigno.github.io/bpf/2021/10/20/ebpf-instruction-sets.html

This requires LLVM v9 and Linux v5.1.

This is older than is required by BTF, which was added in Linux v5.2:

* https://github.com/torvalds/linux/commit/e83b9f55448a

We can reasonably expect that using v3 instruction set doesn't impose any additional constraints on end users, so let's enable it.