### PR TITLE
Bump golangci-lint version to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.0
+          version: v1.51.2
         env:
           CGO_LDFLAGS: "-l bpf"
 


### PR DESCRIPTION
The current version OOMs: https://github.com/golangci/golangci-lint/pull/3414.