### PR TITLE
Update targeted `libbpf` version info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ can use the bundled `Dockerfile` to have `libbpf` compiled in there.
 Note that there's a dependency between `libbpf` version you have installed
 and `libbpfgo`, which is Go's library to talk to `libbpf`
 
-Currently we target `libbpf` v1.0, which has a stable interface.
+Currently we target `libbpf` v1.1, which has a stable interface.
 
 We compile `ebpf_exporter` with `libbpf` statically compiled in,
 so there's only ever a chance of build time issues, never at run time.


### PR DESCRIPTION
The targeted `libbpf` version seems to be bumped from v1.0.1 to v1.1 with commits https://github.com/cloudflare/ebpf_exporter/commit/9a067376798cfaa21c0a88ebd91b14303427a823, and https://github.com/cloudflare/ebpf_exporter/commit/173b1f66a4b34030eb777f46a5c347efa4ebc677.

This change updates the README to reflect the version bump.