### PR TITLE
Add udp packet drops example

### DIFF
--- a/examples/udp-drops.bpf.c
+++ b/examples/udp-drops.bpf.c
@@ -1,0 +1,33 @@
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include "maps.bpf.h"
+
+#define UPPER_PORT_BOUND 9024
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, UPPER_PORT_BOUND);
+    __type(key, u16);
+    __type(value, u64);
+} udp_fail_queue_rcv_skbs_total SEC(".maps");
+
+SEC("tracepoint/udp/udp_fail_queue_rcv_skb")
+int do_count(struct trace_event_raw_udp_fail_queue_rcv_skb *ctx)
+{
+    u16 lport = ctx->lport;
+
+    // We are not interested in ephemeral ports for outbound connections.
+    // There's a ton of them and they don't easily correlate with services.
+    // To still have some visibility, we put all of the ephemeral ports into
+    // the same local_port="0" label and defer to debugging with tracepoints
+    // to find what port and service are having issues.
+    if (lport >= UPPER_PORT_BOUND) {
+        lport = 0;
+    }
+
+    increment_map(&udp_fail_queue_rcv_skbs_total, &lport, 1);
+
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/examples/udp-drops.yaml
+++ b/examples/udp-drops.yaml
@@ -1,0 +1,9 @@
+metrics:
+  counters:
+    - name: udp_fail_queue_rcv_skbs_total
+      help: Total number of UDP SKBs that failed to be delivered due to full receive buffer
+      labels:
+        - name: local_port
+          size: 2
+          decoders:
+            - name: uint


### PR DESCRIPTION
Example metrics:

    $ curl -s http://localhost:3141/metrics | grep udp
    ebpf_exporter_ebpf_program_info{config="udp-drops",id="17383",program="do_count",tag="d9d33581642cbe0a"} 1
    ebpf_exporter_enabled_configs{name="udp-drops"} 1
    # HELP ebpf_exporter_udp_fail_queue_rcv_skbs_total Total number of UDP SKBs that failed to be delivered due to full receive buffer
    # TYPE ebpf_exporter_udp_fail_queue_rcv_skbs_total counter
    ebpf_exporter_udp_fail_queue_rcv_skbs_total{local_port="0"} 144593
    ebpf_exporter_udp_fail_queue_rcv_skbs_total{local_port="2087"} 39
    ebpf_exporter_udp_fail_queue_rcv_skbs_total{local_port="2889"} 3743
    ebpf_exporter_udp_fail_queue_rcv_skbs_total{local_port="443"} 787961
    ebpf_exporter_udp_fail_queue_rcv_skbs_total{local_port="6831"} 73
    ebpf_exporter_udp_fail_queue_rcv_skbs_total{local_port="6852"} 16578
    ebpf_exporter_udp_fail_queue_rcv_skbs_total{local_port="6869"} 13992