### PR TITLE
Only enable libbpf debug log if --debug is passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ To run with [`biolatency`](examples/biolatency.yaml) config:
 sudo ./ebpf_exporter --config.dir examples --config.names biolatency
 ```
 
-If you pass `--debug`, you can see raw maps at `/maps` endpoint.
+If you pass `--debug`, you can see raw maps at `/maps` endpoint
+and see debug output from `libbpf` itself.
 
 ### Docker image
 


### PR DESCRIPTION
Logger callbacks were added by libbpfgo: https://github.com/aquasecurity/libbpfgo/pull/284. This triggered debug output from `libbpf` on `ebpf_exporter`'s startup, which is not desirable. This PR makes debug logs only appear if debug is enabled.

We also pass `libbpf` logs through `log` package to add timestamps and write to `stderr` to match the rest of the logs.