### PR TITLE
Set build as the default goal for make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL := build
+
 BUILD_VAR_PREFIX := github.com/prometheus/common/version
 BUILD_VERSION := $(shell git describe --tags)
 BUILD_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)

--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL := build
+
 .PHONY: clean
 clean:
 	$(MAKE) -C probes clean

--- a/benchmark/probes/Makefile
+++ b/benchmark/probes/Makefile
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL := build
+
 CC := clang
 
 ARCH := $(shell uname -m | sed -e 's/x86_64/x86/' -e 's/aarch64/arm64/')

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL := build
+
 CC := clang
 
 ARCH := $(shell uname -m | sed -e 's/x86_64/x86/' -e 's/aarch64/arm64/')


### PR DESCRIPTION
With this `make -C examples` builds all examples, not just the first one.