### PR TITLE
Replace tracepoint with tp_btf in examples

### DIFF
--- a/examples/cgroup.bpf.c
+++ b/examples/cgroup.bpf.c
@@ -1,5 +1,5 @@
 #include <vmlinux.h>
-#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
 #include "bits.bpf.h"
 #include "maps.bpf.h"
 
@@ -10,13 +10,11 @@ struct {
     __type(value, u64);
 } cgroup_sched_migrations_total SEC(".maps");
 
-SEC("tracepoint/sched/sched_migrate_task")
-int do_count(struct pt_regs *ctx)
+SEC("tp_btf/sched_migrate_task")
+int BPF_PROG(sched_migrate_task)
 {
     u64 cgroup_id = bpf_get_current_cgroup_id();
-
     increment_map(&cgroup_sched_migrations_total, &cgroup_id, 1);
-
     return 0;
 }
 

--- a/examples/syscalls.bpf.c
+++ b/examples/syscalls.bpf.c
@@ -1,5 +1,5 @@
 #include "vmlinux.h"
-#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
 #include "maps.bpf.h"
 
 char LICENSE[] SEC("license") = "GPL";
@@ -11,10 +11,9 @@ struct {
     __type(value, u64);
 } syscalls_total SEC(".maps");
 
-SEC("tracepoint/raw_syscalls/sys_enter")
-int sys_enter(struct trace_event_raw_sys_enter *ctx)
+SEC("tp_btf/sys_enter")
+int BPF_PROG(sys_enter, struct pt_regs *regs, long id)
 {
-    u64 syscall_id = (u64) ctx->id;
-    increment_map(&syscalls_total, &syscall_id, 1);
+    increment_map(&syscalls_total, &id, 1);
     return 0;
 }

--- a/examples/timers.bpf.c
+++ b/examples/timers.bpf.c
@@ -1,5 +1,5 @@
 #include <vmlinux.h>
-#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
 #include "maps.bpf.h"
 
 struct {
@@ -9,13 +9,11 @@ struct {
     __type(value, u64);
 } timer_starts_total SEC(".maps");
 
-SEC("tracepoint/timer/timer_start")
-int do_count(struct trace_event_raw_timer_start *ctx)
+SEC("tp_btf/timer_start")
+int BPF_PROG(timer_start, struct timer_list *timer)
 {
-    u64 function = (u64) ctx->function;
-
+    u64 function = (u64) timer->function;
     increment_map(&timer_starts_total, &function, 1);
-
     return 0;
 }
 

--- a/examples/udp-drops.bpf.c
+++ b/examples/udp-drops.bpf.c
@@ -1,5 +1,5 @@
 #include <vmlinux.h>
-#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
 #include "maps.bpf.h"
 
 #define UPPER_PORT_BOUND 9024
@@ -11,10 +11,10 @@ struct {
     __type(value, u64);
 } udp_fail_queue_rcv_skbs_total SEC(".maps");
 
-SEC("tracepoint/udp/udp_fail_queue_rcv_skb")
-int do_count(struct trace_event_raw_udp_fail_queue_rcv_skb *ctx)
+SEC("tp_btf/udp_fail_queue_rcv_skb")
+int BPF_PROG(udp_fail_queue_rcv_skb, int rc, struct sock *sk)
 {
-    u16 lport = ctx->lport;
+    u16 lport = sk->__sk_common.skc_num;
 
     // We are not interested in ephemeral ports for outbound connections.
     // There's a ton of them and they don't easily correlate with services.


### PR DESCRIPTION
Using `tracepoint` requires access to `tracefs`, which is normally restricted to just root user. We want to reduce the requirements.