### PR TITLE
Simplify oomkill example

### DIFF
--- a/examples/oomkill.bpf.c
+++ b/examples/oomkill.bpf.c
@@ -9,25 +9,17 @@ struct {
     __uint(value_size, sizeof(u32));
 } oom_kills_total SEC(".maps");
 
-struct data_t {
-    u64 cgroup_id;
-    u8 global_oom;
-};
-
 SEC("kprobe/oom_kill_process")
 int BPF_KPROBE(kprobe__oom_kill_process, struct oom_control *oc, const char *message)
 {
-    struct data_t data = {};
+    u64 cgroup_id = 0;
 
     struct mem_cgroup *mcg = BPF_CORE_READ(oc, memcg);
-    if (!mcg) {
-        data.global_oom = 1;
-        bpf_perf_event_output(ctx, &oom_kills_total, BPF_F_CURRENT_CPU, &data, sizeof(data));
-        return 0;
+    if (mcg) {
+        cgroup_id = BPF_CORE_READ(mcg, css.cgroup, kn, id);
     }
 
-    data.cgroup_id = BPF_CORE_READ(mcg, css.cgroup, kn, id);
-    bpf_perf_event_output(ctx, &oom_kills_total, BPF_F_CURRENT_CPU, &data, sizeof(data));
+    bpf_perf_event_output(ctx, &oom_kills_total, BPF_F_CURRENT_CPU, &cgroup_id, sizeof(cgroup_id));
 
     return 0;
 }

--- a/examples/oomkill.yaml
+++ b/examples/oomkill.yaml
@@ -9,7 +9,3 @@ metrics:
           decoders:
             - name: uint
             - name: cgroup
-        - name: global_oom
-          size: 1
-          decoders:
-            - name: uint


### PR DESCRIPTION
Instead of using a separate `global_oom` label just use `cgroup`:

    # HELP ebpf_exporter_oom_kills_total Count global and cgroup level OOMs
    # TYPE ebpf_exporter_oom_kills_total counter
    ebpf_exporter_oom_kills_total{cgroup_path="unknown_cgroup_id:0"} 1

cc @zuzzas 