### PR TITLE
Add kfree_skb example with a reason breakdown

### DIFF
--- a/examples/kfree_skb.bpf.c
+++ b/examples/kfree_skb.bpf.c
@@ -1,0 +1,20 @@
+#include <vmlinux.h>
+#include <bpf/bpf_tracing.h>
+#include "maps.bpf.h"
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 1024);
+    __type(key, u16);
+    __type(value, u64);
+} kfree_skb_total SEC(".maps");
+
+SEC("tp_btf/kfree_skb")
+int BPF_PROG(kfree_skb, struct sk_buff *skb, void *location, enum skb_drop_reason reason)
+{
+    u16 key = reason;
+    increment_map(&kfree_skb_total, &key, 1);
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/examples/kfree_skb.yaml
+++ b/examples/kfree_skb.yaml
@@ -1,0 +1,87 @@
+metrics:
+  counters:
+    - name: kfree_skb_total
+      help: Timers number of calls to kfree_skb
+      labels:
+        - name: reason
+          size: 2
+          decoders:
+            - name: uint
+            - name: static_map
+              static_map:
+                # cat include/arm64/vmlinux.h | grep SKB_DROP_REASON_ | tr -d , | awk '{ printf("%d: %s\n", $3, $1) }'
+                2: SKB_DROP_REASON_NOT_SPECIFIED
+                3: SKB_DROP_REASON_NO_SOCKET
+                4: SKB_DROP_REASON_PKT_TOO_SMALL
+                5: SKB_DROP_REASON_TCP_CSUM
+                6: SKB_DROP_REASON_SOCKET_FILTER
+                7: SKB_DROP_REASON_UDP_CSUM
+                8: SKB_DROP_REASON_NETFILTER_DROP
+                9: SKB_DROP_REASON_OTHERHOST
+                10: SKB_DROP_REASON_IP_CSUM
+                11: SKB_DROP_REASON_IP_INHDR
+                12: SKB_DROP_REASON_IP_RPFILTER
+                13: SKB_DROP_REASON_UNICAST_IN_L2_MULTICAST
+                14: SKB_DROP_REASON_XFRM_POLICY
+                15: SKB_DROP_REASON_IP_NOPROTO
+                16: SKB_DROP_REASON_SOCKET_RCVBUFF
+                17: SKB_DROP_REASON_PROTO_MEM
+                18: SKB_DROP_REASON_TCP_MD5NOTFOUND
+                19: SKB_DROP_REASON_TCP_MD5UNEXPECTED
+                20: SKB_DROP_REASON_TCP_MD5FAILURE
+                21: SKB_DROP_REASON_SOCKET_BACKLOG
+                22: SKB_DROP_REASON_TCP_FLAGS
+                23: SKB_DROP_REASON_TCP_ZEROWINDOW
+                24: SKB_DROP_REASON_TCP_OLD_DATA
+                25: SKB_DROP_REASON_TCP_OVERWINDOW
+                26: SKB_DROP_REASON_TCP_OFOMERGE
+                27: SKB_DROP_REASON_TCP_RFC7323_PAWS
+                28: SKB_DROP_REASON_TCP_INVALID_SEQUENCE
+                29: SKB_DROP_REASON_TCP_RESET
+                30: SKB_DROP_REASON_TCP_INVALID_SYN
+                31: SKB_DROP_REASON_TCP_CLOSE
+                32: SKB_DROP_REASON_TCP_FASTOPEN
+                33: SKB_DROP_REASON_TCP_OLD_ACK
+                34: SKB_DROP_REASON_TCP_TOO_OLD_ACK
+                35: SKB_DROP_REASON_TCP_ACK_UNSENT_DATA
+                36: SKB_DROP_REASON_TCP_OFO_QUEUE_PRUNE
+                37: SKB_DROP_REASON_TCP_OFO_DROP
+                38: SKB_DROP_REASON_IP_OUTNOROUTES
+                39: SKB_DROP_REASON_BPF_CGROUP_EGRESS
+                40: SKB_DROP_REASON_IPV6DISABLED
+                41: SKB_DROP_REASON_NEIGH_CREATEFAIL
+                42: SKB_DROP_REASON_NEIGH_FAILED
+                43: SKB_DROP_REASON_NEIGH_QUEUEFULL
+                44: SKB_DROP_REASON_NEIGH_DEAD
+                45: SKB_DROP_REASON_TC_EGRESS
+                46: SKB_DROP_REASON_QDISC_DROP
+                47: SKB_DROP_REASON_CPU_BACKLOG
+                48: SKB_DROP_REASON_XDP
+                49: SKB_DROP_REASON_TC_INGRESS
+                50: SKB_DROP_REASON_UNHANDLED_PROTO
+                51: SKB_DROP_REASON_SKB_CSUM
+                52: SKB_DROP_REASON_SKB_GSO_SEG
+                53: SKB_DROP_REASON_SKB_UCOPY_FAULT
+                54: SKB_DROP_REASON_DEV_HDR
+                55: SKB_DROP_REASON_DEV_READY
+                56: SKB_DROP_REASON_FULL_RING
+                57: SKB_DROP_REASON_NOMEM
+                58: SKB_DROP_REASON_HDR_TRUNC
+                59: SKB_DROP_REASON_TAP_FILTER
+                60: SKB_DROP_REASON_TAP_TXFILTER
+                61: SKB_DROP_REASON_ICMP_CSUM
+                62: SKB_DROP_REASON_INVALID_PROTO
+                63: SKB_DROP_REASON_IP_INADDRERRORS
+                64: SKB_DROP_REASON_IP_INNOROUTES
+                65: SKB_DROP_REASON_PKT_TOO_BIG
+                66: SKB_DROP_REASON_DUP_FRAG
+                67: SKB_DROP_REASON_FRAG_REASM_TIMEOUT
+                68: SKB_DROP_REASON_FRAG_TOO_FAR
+                69: SKB_DROP_REASON_TCP_MINTTL
+                70: SKB_DROP_REASON_IPV6_BAD_EXTHDR
+                71: SKB_DROP_REASON_IPV6_NDISC_FRAG
+                72: SKB_DROP_REASON_IPV6_NDISC_HOP_LIMIT
+                73: SKB_DROP_REASON_IPV6_NDISC_BAD_CODE
+                74: SKB_DROP_REASON_IPV6_NDISC_BAD_OPTIONS
+                75: SKB_DROP_REASON_IPV6_NDISC_NS_OTHERHOST
+                76: SKB_DROP_REASON_MAX


### PR DESCRIPTION
There's some pushback to more specific tracepoints like udp buffer drops or tcp listen drops upstream:

* https://lore.kernel.org/netdev/20230711193612.22c9bc04@kernel.org/

This adds a kfree_skb tracepoint example, which seems to be the blessed way:

Example metrics:

    # HELP ebpf_exporter_kfree_skb_total Timers number of calls to kfree_skb
    # TYPE ebpf_exporter_kfree_skb_total counter
    ebpf_exporter_kfree_skb_total{reason="SKB_DROP_REASON_NOT_SPECIFIED"} 31
    ebpf_exporter_kfree_skb_total{reason="SKB_DROP_REASON_NO_SOCKET"} 2
    ebpf_exporter_kfree_skb_total{reason="SKB_DROP_REASON_TCP_CLOSE"} 1
    ebpf_exporter_kfree_skb_total{reason="SKB_DROP_REASON_SOCKET_RCVBUFF"} 1.59664e+06