### PR TITLE
Allow suppressing timestamps in logs

### DIFF
--- a/cmd/ebpf_exporter/main.go
+++ b/cmd/ebpf_exporter/main.go
@@ -22,6 +22,7 @@ func main() {
 	configDir := kingpin.Flag("config.dir", "Config dir path.").Required().ExistingDir()
 	configNames := kingpin.Flag("config.names", "Comma separated names of configs to load.").Required().String()
 	debug := kingpin.Flag("debug", "Enable debug.").Bool()
+	noLogTime := kingpin.Flag("log.no-timestamps", "Disable timestamps in log.").Bool()
 	listenAddress := kingpin.Flag("web.listen-address", "The address to listen on for HTTP requests (fd://0 for systemd activation).").Default(":9435").String()
 	metricsPath := kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
 	kingpin.Version(version.Print("ebpf_exporter"))
@@ -33,6 +34,10 @@ func main() {
 		libbpfgoCallbacks.LogFilters = append(libbpfgoCallbacks.LogFilters, func(libLevel int, msg string) bool {
 			return libLevel == libbpfgo.LibbpfDebugLevel
 		})
+	}
+
+	if *noLogTime {
+		log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
 	}
 
 	libbpfgo.SetLoggerCbs(libbpfgoCallbacks)


### PR DESCRIPTION
Having double timestamps when running under systemd makes no sense:

```
$ sudo journalctl -n 4 -u ebpf_exporter
Jul 20 04:37:36 vm ebpf_exporter[23736]: 2023/07/20 04:37:36 Started with capabilities: "cap_syslog,cap_perfmon,cap_bpf=eip"
Jul 20 04:37:36 vm ebpf_exporter[23736]: 2023/07/20 04:37:36 Dropped capabilities to "cap_syslog=ep"
Jul 20 04:37:36 vm ebpf_exporter[23736]: 2023/07/20 04:37:36 Started with 1 programs found in the config in 15ms
Jul 20 04:37:36 vm ebpf_exporter[23736]: 2023/07/20 04:37:36 Listening on fd://0
```

With `--log.no-timestamps`:

```
ivan@vm:~/projects/ebpf_exporter$ sudo journalctl -n 4 -u ebpf_exporter
Jul 21 00:04:39 vm ebpf_exporter[25099]: Started with capabilities: "cap_syslog,cap_perfmon,cap_bpf=eip"
Jul 21 00:04:39 vm ebpf_exporter[25099]: Dropped capabilities to "cap_syslog=ep"
Jul 21 00:04:39 vm ebpf_exporter[25099]: Started with 1 programs found in the config in 16ms
Jul 21 00:04:39 vm ebpf_exporter[25099]: Listening on fd://0
```