### PR TITLE
Add build-dynamic and build-static make goals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,6 @@ GO_LDFLAGS_VARS := -X $(BUILD_VAR_PREFIX).Version=$(BUILD_VERSION) \
 	-X $(BUILD_VAR_PREFIX).BuildUser=$(BUILD_USER) \
 	-X $(BUILD_VAR_PREFIX).BuildDate=$(BUILD_DATE)
 
-GO_LDFLAGS := -ldflags="-extldflags "-static" $(GO_LDFLAGS_VARS)"
-
 CLANG_FORMAT_FILES = ${wildcard examples/*.c examples/*.h benchmark/probes/*.c benchmark/probes/*.h}
 
 export CGO_LDFLAGS := -l bpf
@@ -33,8 +31,20 @@ test:
 	go test -v ./...
 
 .PHONY: build
-build:
-	go build -o ebpf_exporter -v $(GO_LDFLAGS) ./cmd/ebpf_exporter
+build: build-static
 
+.PHONY: build-static
+build-static:
+	$(MAKE) build-binary GO_LDFLAGS='-extldflags "-static"'
+
+.PHONY: build-dynamic
+build-dynamic:
+	$(MAKE) build-binary
+
+.PHONY: build-binary
+build-binary:
+	go build -o ebpf_exporter -v -ldflags="$(GO_LDFLAGS) $(GO_LDFLAGS_VARS)" ./cmd/ebpf_exporter
+
+.PHONY: syscalls
 syscalls:
 	go run ./scripts/mksyscalls --strace.version v6.4

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ To build a binary, clone the repo and run:
 make build
 ```
 
+The default `build` target makes a static binary, but you could also
+use `build-dynamic` if you'd like a dynamically linked binary. This could
+be useful if your build system does not have static archives for dependencies
+like `libbpf.a` and `libelf.a`. Static build is usually preferred.
+
 If you're having trouble building on the host, you can try building in Docker:
 
 ```


### PR DESCRIPTION
A dynamic build might be useful if there are no static archives present for depenencies like libbpf and libelf.

```
ivan@vm:~/projects/ebpf_exporter$ make build-static
...
ivan@vm:~/projects/ebpf_exporter$ ldd ebpf_exporter
    not a dynamic executable
```

```
ivan@vm:~/projects/ebpf_exporter$ make build-dynamic
...
ivan@vm:~/projects/ebpf_exporter$ ldd ebpf_exporter
    linux-vdso.so.1 (0x0000007f85ee5000)
    libbpf.so.1 => /lib/aarch64-linux-gnu/libbpf.so.1 (0x0000007f85e30000)
    libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000007f85c80000)
    libelf.so.1 => /lib/aarch64-linux-gnu/libelf.so.1 (0x0000007f85c40000)
    libz.so.1 => /lib/aarch64-linux-gnu/libz.so.1 (0x0000007f85c00000)
    /lib/ld-linux-aarch64.so.1 (0x0000007f85ea8000)
```