### PR TITLE
Add linguist ignores for vmlinux.h

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+include/arm64/vmlinux.h linguist-generated
+include/x86/vmlinux.h   linguist-generated


### PR DESCRIPTION
Fixing this:

<img width="325" alt="image" src="https://github.com/cloudflare/ebpf_exporter/assets/89186/74dbb6a9-b0f1-4df6-b9b9-9d9dc46ecc8e">

Before:

```
ivan@vm:~/projects/ebpf_exporter$ github-linguist
98.67%  6661642    C
1.29%   86868      Go
0.03%   1785       Makefile
0.01%   881        Dockerfile
```

After:

```
ivan@vm:~/projects/ebpf_exporter$ github-linguist
93.39%  86868      Go
3.75%   3485       C
1.92%   1785       Makefile
0.95%   881        Dockerfile
```