### PR TITLE
Add icmp-ip example with inet_ip decoder

### DIFF
--- a/examples/icmp-ip.bpf.c
+++ b/examples/icmp-ip.bpf.c
@@ -1,0 +1,68 @@
+#include <vmlinux.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+#include "maps.bpf.h"
+
+#define IPHDR_ADDR(skb) BPF_CORE_READ(skb, head) + BPF_CORE_READ(skb, network_header)
+
+struct icmp4_key_t {
+    u32 addr;
+};
+
+struct icmp6_key_t {
+    u8 addr[16];
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 10240);
+    __type(key, struct icmp4_key_t);
+    __type(value, u64);
+} icmp4_received_packets_total SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 10240);
+    __type(key, struct icmp6_key_t);
+    __type(value, u64);
+} icmp6_received_packets_total SEC(".maps");
+
+// kprobe for compatibility, please prefer fentry instead
+SEC("kprobe/icmp_rcv")
+int BPF_PROG(icmp_rcv, struct sk_buff *skb)
+{
+    struct iphdr ip_hdr;
+    struct icmp4_key_t key;
+
+    if (bpf_probe_read_kernel(&ip_hdr, sizeof(ip_hdr), IPHDR_ADDR(skb)) < 0) {
+        return 0;
+    }
+
+    key.addr = ip_hdr.saddr;
+
+    increment_map(&icmp4_received_packets_total, &key, 1);
+
+    return 0;
+}
+
+// kprobe for compatibility, please prefer fentry instead
+SEC("kprobe/icmpv6_rcv")
+int BPF_PROG(icmpv6_rcv, struct sk_buff *skb)
+{
+    struct ipv6hdr ipv6_hdr;
+    struct icmp6_key_t key;
+
+    if (bpf_probe_read_kernel(&ipv6_hdr, sizeof(ipv6_hdr), IPHDR_ADDR(skb)) < 0) {
+        return 0;
+    }
+
+    if (bpf_probe_read_kernel(&key.addr, sizeof(key.addr), ipv6_hdr.saddr.in6_u.u6_addr8) < 0) {
+        return 0;
+    }
+
+    increment_map(&icmp6_received_packets_total, &key, 1);
+
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/examples/icmp-ip.yaml
+++ b/examples/icmp-ip.yaml
@@ -1,0 +1,16 @@
+metrics:
+  counters:
+    - name: icmp4_received_packets_total
+      help: Number of icmp packets received over IPv4
+      labels:
+        - name: source_addr
+          size: 4
+          decoders:
+            - name: inet_ip
+    - name: icmp6_received_packets_total
+      help: Number of icmp packets received over IPv6
+      labels:
+        - name: source_addr
+          size: 16
+          decoders:
+            - name: inet_ip


### PR DESCRIPTION
Example metrics from local pings:

    ivan@vm:~$ curl -s http://localhost:9435/metrics | fgrep ebpf_exporter_icmp
    # HELP ebpf_exporter_icmp4_received_packets_total Number of icmp packets received over IPv4
    # TYPE ebpf_exporter_icmp4_received_packets_total counter
    ebpf_exporter_icmp4_received_packets_total{source_addr="10.2.0.15"} 4
    ebpf_exporter_icmp4_received_packets_total{source_addr="127.0.0.1"} 6
    # HELP ebpf_exporter_icmp6_received_packets_total Number of icmp packets received over IPv6
    # TYPE ebpf_exporter_icmp6_received_packets_total counter
    ebpf_exporter_icmp6_received_packets_total{source_addr="::1"} 4
    ebpf_exporter_icmp6_received_packets_total{source_addr="fe80::5054:ff:fe12:3456"} 4
    ebpf_exporter_icmp6_received_packets_total{source_addr="fec0::5054:ff:fe12:3456"} 6