### PR TITLE
Use readlink instead of filepath.EvalSymlinks for fewer syscalls

### DIFF
--- a/cgroup/fanotify.go
+++ b/cgroup/fanotify.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"path/filepath"
 	"syscall"
 
 	"github.com/cloudflare/ebpf_exporter/v2/util"
@@ -144,7 +143,7 @@ func (m *fanotifyMonitor) resolveDir(handle unix.FileHandle) (string, error) {
 
 	defer syscall.Close(fd)
 
-	dir, err := filepath.EvalSymlinks(fmt.Sprintf("/proc/self/fd/%d", fd))
+	dir, err := os.Readlink(fmt.Sprintf("/proc/self/fd/%d", fd))
 	if err != nil {
 		return "", fmt.Errorf("error resolving event fd symlink: %v", err)
 	}


### PR DESCRIPTION
Restarting a systemd unit:

```
ivan@vm:~$ sudo systemctl restart systemd-resolved
```

Before: 10x `newfstatat` + 2x `readlinkat`

```
ivan@vm:~$ sudo strace -f -TT -e open_by_handle_at,newfstatat,readlinkat -p $(pidof ebpf_exporter)
strace: Process 13503 attached with 9 threads
[pid 13507] open_by_handle_at(7, {handle_bytes=8, handle_type=254, f_handle="\x36\x00\x00\x00\x00\x00\x00\x00"}, O_RDONLY) = 13 <0.000519>
[pid 13507] newfstatat(AT_FDCWD, "/proc", {st_mode=S_IFDIR|0555, st_size=0, ...}, AT_SYMLINK_NOFOLLOW) = 0 <0.000821>
[pid 13507] newfstatat(AT_FDCWD, "/proc/self", {st_mode=S_IFLNK|0777, st_size=0, ...}, AT_SYMLINK_NOFOLLOW) = 0 <0.001389>
[pid 13507] readlinkat(AT_FDCWD, "/proc/self", "13503", 128) = 5 <0.000577>
[pid 13507] newfstatat(AT_FDCWD, "/proc/13503", {st_mode=S_IFDIR|0555, st_size=0, ...}, AT_SYMLINK_NOFOLLOW) = 0 <0.000835>
[pid 13507] newfstatat(AT_FDCWD, "/proc/13503/fd", {st_mode=S_IFDIR|0500, st_size=14, ...}, AT_SYMLINK_NOFOLLOW) = 0 <0.000872>
[pid 13507] newfstatat(AT_FDCWD, "/proc/13503/fd/13", {st_mode=S_IFLNK|0500, st_size=64, ...}, AT_SYMLINK_NOFOLLOW) = 0 <0.000373>
[pid 13507] readlinkat(AT_FDCWD, "/proc/13503/fd/13", "/sys/fs/cgroup/system.slice", 128) = 27 <0.000750>
[pid 13507] newfstatat(AT_FDCWD, "/sys", {st_mode=S_IFDIR|0555, st_size=0, ...}, AT_SYMLINK_NOFOLLOW) = 0 <0.000855>
[pid 13507] newfstatat(AT_FDCWD, "/sys/fs", {st_mode=S_IFDIR|0755, st_size=0, ...}, AT_SYMLINK_NOFOLLOW) = 0 <0.000695>
[pid 13507] newfstatat(AT_FDCWD, "/sys/fs/cgroup", {st_mode=S_IFDIR|0555, st_size=0, ...}, AT_SYMLINK_NOFOLLOW) = 0 <0.001007>
[pid 13507] newfstatat(AT_FDCWD, "/sys/fs/cgroup/system.slice", {st_mode=S_IFDIR|0755, st_size=0, ...}, AT_SYMLINK_NOFOLLOW) = 0 <0.000586>
[pid 13507] newfstatat(AT_FDCWD, "/sys/fs/cgroup/system.slice/systemd-resolved.service", {st_mode=S_IFDIR|0755, st_size=0, ...}, 0) = 0 <0.000598>
```

After: 1x `newfstatat` + 1x `readlinkat`

```
ivan@vm:~$ sudo strace -f -TT -e open_by_handle_at,newfstatat,readlinkat -p $(pidof ebpf_exporter)
strace: Process 13290 attached with 10 threads
[pid 13290] open_by_handle_at(7, {handle_bytes=8, handle_type=254, f_handle="\x36\x00\x00\x00\x00\x00\x00\x00"}, O_RDONLY) = 13 <0.000319>
[pid 13290] readlinkat(AT_FDCWD, "/proc/self/fd/13", "/sys/fs/cgroup/system.slice", 128) = 27 <0.000027>
[pid 13290] newfstatat(AT_FDCWD, "/sys/fs/cgroup/system.slice/systemd-resolved.service", {st_mode=S_IFDIR|0755, st_size=0, ...}, 0) = 0 <0.001083>
```

Hopefully this helps with super-short lived cgroup detection.