### PR TITLE
Enable stylecheck

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,6 +21,7 @@ linters:
     - promlinter
     - reassign
     - revive
+    - stylecheck
     - tagalign
     - unconvert
     - unparam


### PR DESCRIPTION
Mostly to catch error capitalization:

```
ivan@vm:~/projects/ebpf_exporter$ make lint
go mod verify
all modules verified
golangci-lint run ./...
cgroup/fanotify.go:123:10: ST1005: error strings should not be capitalized (stylecheck)
		return fmt.Errorf("Error reading file_handle: %v", err)
		       ^
make: *** [Makefile:36: lint] Error 1
```