### PR TITLE
Use fewer dependencies for libbpf build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM debian:bookworm as libbpf_builder
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git ca-certificates build-essential libelf-dev
+    apt-get install -y --no-install-recommends git ca-certificates gcc make libelf-dev
 
 RUN mkdir /build && \
     git clone --branch v1.2.0 --depth 1 https://github.com/libbpf/libbpf.git /build/libbpf && \


### PR DESCRIPTION
Before:

```
0 upgraded, 74 newly installed, 0 to remove and 0 not upgraded.
Need to get 81.4 MB of archives.
```

After:

```
0 upgraded, 65 newly installed, 0 to remove and 0 not upgraded.
Need to get 67.7 MB of archives.
```