### PR TITLE
Do not complain about lack of fanotify too loudly

### DIFF
--- a/cgroup/monitor.go
+++ b/cgroup/monitor.go
@@ -17,7 +17,8 @@ type Monitor struct {
 func NewMonitor(path string) (*Monitor, error) {
 	fm, err := newFanotifyMonitor(path)
 	if err != nil {
-		log.Printf("Error attaching fanotify, using on-demand resolution instead: %v", err)
+		log.Printf("Using on-demand resolution for cgroups (fanotify not available)")
+
 		wm, err := newWalkerMonitor(path)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
People get confused by the word "error" and it's not really an error if fanotify is not available (#277, #278). Let's adjust the log message accordingly.

Before:

```
Error attaching fanotify, using on-demand resolution instead: error calling fanotify_mark for "/sys/fs/cgroup": no such device
```

After:

```
Using on-demand resolution for cgroups (fanotify not available)
```