### PR TITLE
Add exp2zero histogram type

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,9 +409,9 @@ the missing data.
 
 That's why for histogram configuration we have the following keys:
 
-* `bucket_type`: can be either `exp2`, `linear`, or `fixed`
-* `bucket_min`: minimum bucket key (`exp2` and `linear` only)
-* `bucket_max`: maximum bucket key (`exp2` and `linear` only)
+* `bucket_type`: can be either `exp2`, `exp2zero`, `linear`, or `fixed`
+* `bucket_min`: minimum bucket key (`exp2`, `exp2zero` and `linear` only)
+* `bucket_max`: maximum bucket key (`exp2`, `exp2zero` and `linear` only)
 * `bucket_keys`: maximum bucket key (`fixed` only)
 * `bucket_multiplier`: multiplier for bucket keys (default is `1`)
 
@@ -432,6 +432,20 @@ for i = bucket_min; i < bucket_max; i++ {
 Here `map` is the map from the kernel and `result` is what goes to prometheus.
 
 We take cumulative `count`, because this is what prometheus expects.
+
+##### `exp2zero` histograms
+
+These are the same as `exp2` histograms, except:
+
+* The first key is for the value `0`
+* All other keys are `1` larger than they should be
+
+This is useful if your actual observed value can be zero, as regular `exp2`
+histograms cannot express this due the the fact that `log2(0)` is invalid,
+and in fact BPF treats `log2(0)` as `0`, and `exp2(0)` is 1, not 0.
+
+See [`tcp-syn-backlog-exp2zero.bpf.c`](examples/tcp-syn-backlog-exp2zero.bpf.c)
+for an example of a config that makes use of this.
 
 ##### `linear` histograms
 

--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,8 @@ type HistogramBucketType string
 const (
 	// HistogramBucketExp2 means histograms with power-of-two keys
 	HistogramBucketExp2 HistogramBucketType = "exp2"
+	// HistogramBucketExp2WithZero means histograms with power-of-two keys where the first key is for zero
+	HistogramBucketExp2WithZero HistogramBucketType = "exp2zero"
 	// HistogramBucketLinear means histogram with linear keys
 	HistogramBucketLinear HistogramBucketType = "linear"
 	// HistogramBucketFixed means histogram with fixed user-defined keys

--- a/examples/tcp-syn-backlog-exp2zero.bpf.c
+++ b/examples/tcp-syn-backlog-exp2zero.bpf.c
@@ -1,0 +1,56 @@
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+#include "bits.bpf.h"
+#include "maps.bpf.h"
+
+// 17 buckets, max range is 32k..64k
+#define MAX_BUCKET_SLOT 17
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, MAX_BUCKET_SLOT + 2);
+    __type(key, u64);
+    __type(value, u64);
+} tcp_syn_backlog SEC(".maps");
+
+static int do_count(u64 backlog)
+{
+    u64 bucket;
+
+    // Histogram key for exp2zero
+    if (backlog == 0) {
+        bucket = 0;
+    } else {
+        bucket = log2l(backlog) + 1;
+    }
+
+    if (bucket > MAX_BUCKET_SLOT) {
+        bucket = MAX_BUCKET_SLOT;
+    }
+
+    increment_map(&tcp_syn_backlog, &bucket, 1);
+
+    // No use incrementing by zero
+    if (backlog > 0) {
+        bucket = MAX_BUCKET_SLOT + 1;
+        increment_map(&tcp_syn_backlog, &bucket, backlog);
+    }
+
+    return 0;
+}
+
+SEC("kprobe/tcp_v4_syn_recv_sock")
+int BPF_KPROBE(kprobe__tcp_v4_syn_recv_sock, struct sock *sk)
+{
+    return do_count(BPF_CORE_READ(sk, sk_ack_backlog) / 50);
+}
+
+SEC("kprobe/tcp_v6_syn_recv_sock")
+int BPF_KPROBE(kprobe__tcp_v6_syn_recv_sock, struct sock *sk)
+{
+    return do_count(BPF_CORE_READ(sk, sk_ack_backlog) / 50);
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/examples/tcp-syn-backlog-exp2zero.yaml
+++ b/examples/tcp-syn-backlog-exp2zero.yaml
@@ -1,0 +1,12 @@
+metrics:
+  histograms:
+    - name: tcp_syn_backlog
+      help: TCP SYN backlog size
+      bucket_type: exp2zero
+      bucket_min: 0
+      bucket_max: 17
+      labels:
+        - name: bucket
+          size: 8
+          decoders:
+            - name: uint

--- a/exporter/histogram.go
+++ b/exporter/histogram.go
@@ -25,6 +25,14 @@ func histogramKeyerMaker(histogram config.Histogram) (histogramKeyer, error) {
 		return func(bucket float64) float64 {
 			return math.Exp2(bucket) * multiplier
 		}, nil
+	case config.HistogramBucketExp2WithZero:
+		return func(bucket float64) float64 {
+			if bucket == 0 {
+				return 0
+			}
+
+			return math.Exp2(bucket-1) * multiplier
+		}, nil
 	case config.HistogramBucketLinear:
 		return func(bucket float64) float64 {
 			return bucket * multiplier


### PR DESCRIPTION
This makes it possible to have a bucket for the zero value, which is very useful if zero is the most common observed value:

    ivan@vm:~$ curl -s http://ip6-localhost:9435/metrics | fgrep tcp_syn_backlog
    # HELP ebpf_exporter_tcp_syn_backlog TCP SYN backlog size
    # TYPE ebpf_exporter_tcp_syn_backlog histogram
    ebpf_exporter_tcp_syn_backlog_bucket{le="0"} 19
    ebpf_exporter_tcp_syn_backlog_bucket{le="1"} 19
    ebpf_exporter_tcp_syn_backlog_bucket{le="2"} 19
    ebpf_exporter_tcp_syn_backlog_bucket{le="4"} 19
    ebpf_exporter_tcp_syn_backlog_bucket{le="8"} 19
    ebpf_exporter_tcp_syn_backlog_bucket{le="16"} 19
    ebpf_exporter_tcp_syn_backlog_bucket{le="32"} 19
    ebpf_exporter_tcp_syn_backlog_bucket{le="64"} 19
    ebpf_exporter_tcp_syn_backlog_bucket{le="128"} 19
    ebpf_exporter_tcp_syn_backlog_bucket{le="256"} 19
    ebpf_exporter_tcp_syn_backlog_bucket{le="512"} 19
    ebpf_exporter_tcp_syn_backlog_bucket{le="1024"} 19
    ebpf_exporter_tcp_syn_backlog_bucket{le="2048"} 19
    ebpf_exporter_tcp_syn_backlog_bucket{le="4096"} 19
    ebpf_exporter_tcp_syn_backlog_bucket{le="8192"} 19
    ebpf_exporter_tcp_syn_backlog_bucket{le="16384"} 19
    ebpf_exporter_tcp_syn_backlog_bucket{le="32768"} 19
    ebpf_exporter_tcp_syn_backlog_bucket{le="65536"} 19
    ebpf_exporter_tcp_syn_backlog_bucket{le="+Inf"} 19
    ebpf_exporter_tcp_syn_backlog_sum 0
    ebpf_exporter_tcp_syn_backlog_count 19