### PR TITLE
Disable provenance for docker images due to github registry bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,3 +416,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+          provenance: false # https://github.com/docker/build-push-action/issues/755


### PR DESCRIPTION
Having `unknown/unknown` is weird:

<img width="761" alt="image" src="https://github.com/cloudflare/ebpf_exporter/assets/89186/f32a4909-7f0d-4f5a-aeec-01ed7e86f8fe">
