### PR TITLE
Fix uint decoder for large u64 numbers

### DIFF
--- a/decoder/uint.go
+++ b/decoder/uint.go
@@ -2,7 +2,6 @@ package decoder
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/cloudflare/ebpf_exporter/v2/config"
 	"github.com/cloudflare/ebpf_exporter/v2/util"
@@ -30,5 +29,5 @@ func (u *UInt) Decode(in []byte, _ config.Decoder) ([]byte, error) {
 		return nil, fmt.Errorf("unknown value length %d for %#v", len(in), in)
 	}
 
-	return []byte(strconv.Itoa(int(result))), nil
+	return []byte(fmt.Sprintf("%d", result)), nil
 }

--- a/decoder/uint_test.go
+++ b/decoder/uint_test.go
@@ -29,6 +29,14 @@ func TestUIntDecoder(t *testing.T) {
 			in:  []byte{0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
 			out: []byte(strconv.Itoa(int(8))),
 		},
+		{
+			in:  []byte{0x0, 0xb6, 0xc2, 0x5b, 0x85, 0xff, 0xff, 0xff},
+			out: []byte("18446743546968061440"),
+		},
+		{
+			in:  []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			out: []byte("18446744073709551615"),
+		},
 	}
 
 	for _, c := range cases {
@@ -40,7 +48,7 @@ func TestUIntDecoder(t *testing.T) {
 		}
 
 		if !bytes.Equal(out, c.out) {
-			t.Errorf("Expected %#v, got %#v", c.out, out)
+			t.Errorf("Expected %s, got %s", string(c.out), string(out))
 		}
 	}
 }


### PR DESCRIPTION
The newly added test fail without the decoder change:

```
=== RUN   TestUIntDecoder
    uint_test.go:51: Expected 18446743546968061440, got -526741490176
    uint_test.go:51: Expected 18446744073709551615, got -1
```