### PR TITLE
Add softirq-latency example

### DIFF
--- a/examples/softirq-latency.bpf.c
+++ b/examples/softirq-latency.bpf.c
@@ -1,0 +1,139 @@
+#include <vmlinux.h>
+#include <bpf/bpf_tracing.h>
+#include "bits.bpf.h"
+#include "maps.bpf.h"
+
+// Loosely based on https://github.com/xdp-project/xdp-project/blob/master/areas/latency/softirq_net_latency.bt
+
+// 20 buckets for latency, max range is 0.5s .. 1.0s
+#define MAX_LATENCY_SLOT 21
+
+struct softirq_latency_key_t {
+    u32 kind;
+    u64 bucket;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(max_entries, NR_SOFTIRQS);
+    __type(key, u32);
+    __type(value, u64);
+} softirq_raised_total SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(max_entries, NR_SOFTIRQS);
+    __type(key, u32);
+    __type(value, u64);
+} softirq_serviced_total SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(max_entries, NR_SOFTIRQS);
+    __type(key, u32);
+    __type(value, u64);
+} softirq_raise_timestamp SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(max_entries, NR_SOFTIRQS);
+    __type(key, u32);
+    __type(value, u64);
+} softirq_entry_timestamp SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __uint(max_entries, (MAX_LATENCY_SLOT + 1) * NR_SOFTIRQS);
+    __type(key, struct softirq_latency_key_t);
+    __type(value, u64);
+} softirq_entry_latency_seconds SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __uint(max_entries, (MAX_LATENCY_SLOT + 1) * NR_SOFTIRQS);
+    __type(key, struct softirq_latency_key_t);
+    __type(value, u64);
+} softirq_service_latency_seconds SEC(".maps");
+
+SEC("tp_btf/softirq_raise")
+int BPF_PROG(softirq_raise, unsigned int vec_nr)
+{
+    u64 *existing_ts_ptr, *raised_total_ptr, ts = bpf_ktime_get_ns();
+
+    read_array_ptr(&softirq_raised_total, &vec_nr, raised_total_ptr);
+    *raised_total_ptr += 1;
+
+    read_array_ptr(&softirq_raise_timestamp, &vec_nr, existing_ts_ptr);
+
+    // Set the timestamp only if it is not set, so that we always measure the oldest non-entered raise
+    if (!*existing_ts_ptr) {
+        *existing_ts_ptr = ts;
+    }
+
+    return 0;
+}
+
+SEC("tp_btf/softirq_entry")
+int BPF_PROG(softirq_entry, unsigned int vec_nr)
+{
+    u64 delta_us, *raise_ts_ptr, *existing_entry_ts_ptr, *serviced_total_ptr, ts = bpf_ktime_get_ns();
+    struct softirq_latency_key_t key = {};
+
+    read_array_ptr(&softirq_serviced_total, &vec_nr, serviced_total_ptr);
+    *serviced_total_ptr += 1;
+
+    read_array_ptr(&softirq_raise_timestamp, &vec_nr, raise_ts_ptr);
+
+    // Interrupt was re-rased after ts was obtained, resulting in negative duration
+    if (*raise_ts_ptr > ts) {
+        return 0;
+    }
+
+    // Interrupt entry started with no corresponding raise, resulting in large duration
+    if (!*raise_ts_ptr) {
+        return 0;
+    }
+
+    delta_us = (ts - *raise_ts_ptr) / 1000;
+
+    key.kind = vec_nr;
+
+    increment_exp2_histogram(&softirq_entry_latency_seconds, key, delta_us, MAX_LATENCY_SLOT);
+
+    // Allow raise timestamp to be set again
+    *raise_ts_ptr = 0;
+
+    read_array_ptr(&softirq_entry_timestamp, &vec_nr, existing_entry_ts_ptr);
+
+    // There is some time from function start to here, so overall service time includes it
+    *existing_entry_ts_ptr = ts;
+
+    return 0;
+}
+
+SEC("tp_btf/softirq_exit")
+int BPF_PROG(softirq_exit, unsigned int vec_nr)
+{
+    u64 delta_us, *entry_ts_ptr, ts = bpf_ktime_get_ns();
+    struct softirq_latency_key_t key = {};
+
+    read_array_ptr(&softirq_entry_timestamp, &vec_nr, entry_ts_ptr);
+
+    // Interrupt exited with no corresponding entry, resulting in large duration
+    if (!*entry_ts_ptr) {
+        return 0;
+    }
+
+    delta_us = (ts - *entry_ts_ptr) / 1000;
+
+    key.kind = vec_nr;
+
+    increment_exp2_histogram(&softirq_service_latency_seconds, key, delta_us, MAX_LATENCY_SLOT);
+
+    // Reset entry ts to prevent skipped entries to be counted at exit
+    *entry_ts_ptr = 0;
+
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/examples/softirq-latency.yaml
+++ b/examples/softirq-latency.yaml
@@ -1,0 +1,95 @@
+metrics:
+  histograms:
+    - name: softirq_entry_latency_seconds
+      help: Latency histogram for how long it takes from softirq raise to entry
+      bucket_type: exp2
+      bucket_min: 0
+      bucket_max: 21
+      bucket_multiplier: 0.000001 # nano to seconds
+      labels:
+        - name: kind
+          size: 8
+          decoders:
+            - name: uint
+            - name: static_map
+              static_map:
+                0: HI_SOFTIRQ
+                1: TIMER_SOFTIRQ
+                2: NET_TX_SOFTIRQ
+                3: NET_RX_SOFTIRQ
+                4: BLOCK_SOFTIRQ
+                5: IRQ_POLL_SOFTIRQ
+                6: TASKLET_SOFTIRQ
+                7: SCHED_SOFTIRQ
+                8: HRTIMER_SOFTIRQ
+                9: RCU_SOFTIRQ
+        - name: bucket
+          size: 8
+          decoders:
+            - name: uint
+    - name: softirq_service_latency_seconds
+      help: Latency histogram for how long it takes from softirq entry to exit
+      bucket_type: exp2
+      bucket_min: 0
+      bucket_max: 21
+      bucket_multiplier: 0.000001 # nano to seconds
+      labels:
+        - name: kind
+          size: 8
+          decoders:
+            - name: uint
+            - name: static_map
+              static_map:
+                0: HI_SOFTIRQ
+                1: TIMER_SOFTIRQ
+                2: NET_TX_SOFTIRQ
+                3: NET_RX_SOFTIRQ
+                4: BLOCK_SOFTIRQ
+                5: IRQ_POLL_SOFTIRQ
+                6: TASKLET_SOFTIRQ
+                7: SCHED_SOFTIRQ
+                8: HRTIMER_SOFTIRQ
+                9: RCU_SOFTIRQ
+        - name: bucket
+          size: 8
+          decoders:
+            - name: uint
+  counters:
+    - name: softirq_raised_total
+      help: Total number of times softirq were raised
+      labels:
+        - name: kind
+          size: 4
+          decoders:
+            - name: uint
+            - name: static_map
+              static_map:
+                0: HI_SOFTIRQ
+                1: TIMER_SOFTIRQ
+                2: NET_TX_SOFTIRQ
+                3: NET_RX_SOFTIRQ
+                4: BLOCK_SOFTIRQ
+                5: IRQ_POLL_SOFTIRQ
+                6: TASKLET_SOFTIRQ
+                7: SCHED_SOFTIRQ
+                8: HRTIMER_SOFTIRQ
+                9: RCU_SOFTIRQ
+    - name: softirq_serviced_total
+      help: Total number of times softirq were serviced
+      labels:
+        - name: kind
+          size: 4
+          decoders:
+            - name: uint
+            - name: static_map
+              static_map:
+                0: HI_SOFTIRQ
+                1: TIMER_SOFTIRQ
+                2: NET_TX_SOFTIRQ
+                3: NET_RX_SOFTIRQ
+                4: BLOCK_SOFTIRQ
+                5: IRQ_POLL_SOFTIRQ
+                6: TASKLET_SOFTIRQ
+                7: SCHED_SOFTIRQ
+                8: HRTIMER_SOFTIRQ
+                9: RCU_SOFTIRQ


### PR DESCRIPTION
Example for NET_RX:

    ivan@vm:~$ curl -s http://ip6-localhost:9435/metrics | fgrep softirq | fgrep NET_RX_SOFTIRQ
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="1e-06"} 165
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="2e-06"} 167
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="4e-06"} 176
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="8e-06"} 271
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="1.6e-05"} 406
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="3.2e-05"} 452
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="6.4e-05"} 468
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.000128"} 477
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.000256"} 480
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.000512"} 480
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.001024"} 480
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.002048"} 480
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.004096"} 480
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.008192"} 480
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.016384"} 480
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.032768"} 480
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.065536"} 480
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.131072"} 480
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.262144"} 480
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.524288"} 480
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="1.048576"} 480
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="2.097152"} 480
    ebpf_exporter_softirq_entry_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="+Inf"} 480
    ebpf_exporter_softirq_entry_latency_seconds_sum{kind="NET_RX_SOFTIRQ"} 0.010152
    ebpf_exporter_softirq_entry_latency_seconds_count{kind="NET_RX_SOFTIRQ"} 480
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="1e-06"} 42
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="2e-06"} 77
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="4e-06"} 140
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="8e-06"} 191
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="1.6e-05"} 276
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="3.2e-05"} 375
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="6.4e-05"} 422
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.000128"} 471
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.000256"} 477
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.000512"} 480
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.001024"} 480
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.002048"} 480
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.004096"} 480
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.008192"} 480
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.016384"} 480
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.032768"} 480
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.065536"} 480
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.131072"} 480
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.262144"} 480
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="0.524288"} 480
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="1.048576"} 480
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="2.097152"} 480
    ebpf_exporter_softirq_service_latency_seconds_bucket{kind="NET_RX_SOFTIRQ",le="+Inf"} 480
    ebpf_exporter_softirq_service_latency_seconds_sum{kind="NET_RX_SOFTIRQ"} 0.024145
    ebpf_exporter_softirq_service_latency_seconds_count{kind="NET_RX_SOFTIRQ"} 480

cc @netoptimizer