### PR TITLE
Remove copy-pasted division by 50 in tcp-syn-backlog-exp2zero

### DIFF
--- a/examples/tcp-syn-backlog-exp2zero.bpf.c
+++ b/examples/tcp-syn-backlog-exp2zero.bpf.c
@@ -44,13 +44,13 @@ static int do_count(u64 backlog)
 SEC("kprobe/tcp_v4_syn_recv_sock")
 int BPF_KPROBE(kprobe__tcp_v4_syn_recv_sock, struct sock *sk)
 {
-    return do_count(BPF_CORE_READ(sk, sk_ack_backlog) / 50);
+    return do_count(BPF_CORE_READ(sk, sk_ack_backlog));
 }
 
 SEC("kprobe/tcp_v6_syn_recv_sock")
 int BPF_KPROBE(kprobe__tcp_v6_syn_recv_sock, struct sock *sk)
 {
-    return do_count(BPF_CORE_READ(sk, sk_ack_backlog) / 50);
+    return do_count(BPF_CORE_READ(sk, sk_ack_backlog));
 }
 
 char LICENSE[] SEC("license") = "GPL";


### PR DESCRIPTION
It was copy-pasted from tcp-syn-backlog and it is not needed here.