### PR TITLE
Add `{increment_map,increment_{exp2,ex2zero}_histogram}_nosync`

### DIFF
--- a/examples/maps.bpf.h
+++ b/examples/maps.bpf.h
@@ -1,17 +1,32 @@
-static int increment_map(void *map, void *key, u64 increment)
-{
-    u64 zero = 0, *count = bpf_map_lookup_elem(map, key);
-    if (!count) {
-        bpf_map_update_elem(map, key, &zero, BPF_NOEXIST);
-        count = bpf_map_lookup_elem(map, key);
-        if (!count) {
-            return 0;
-        }
+#define lookup_or_zero_init_key(map, key, into)                                                                        \
+    u64 zero = 0;                                                                                                      \
+                                                                                                                       \
+    into = bpf_map_lookup_elem(map, key);                                                                              \
+    if (!into) {                                                                                                       \
+        bpf_map_update_elem(map, key, &zero, BPF_NOEXIST);                                                             \
+        into = bpf_map_lookup_elem(map, key);                                                                          \
+        if (!into) {                                                                                                   \
+            return 0;                                                                                                  \
+        }                                                                                                              \
     }
 
-    __sync_fetch_and_add(count, increment);
-
+#define increment_variant(map, key, increment, variant)                                                                \
+    u64 *count;                                                                                                        \
+                                                                                                                       \
+    lookup_or_zero_init_key(map, key, count);                                                                          \
+                                                                                                                       \
+    variant;                                                                                                           \
+                                                                                                                       \
     return *count;
+
+static inline int increment_map(void *map, void *key, u64 increment)
+{
+    increment_variant(map, key, increment, __sync_fetch_and_add(count, increment));
+}
+
+static inline int increment_map_nosync(void *map, void *key, u64 increment)
+{
+    increment_variant(map, key, increment, *count += increment);
 }
 
 // Arrays are always preallocated, so this only fails if the key is missing
@@ -21,32 +36,44 @@ static int increment_map(void *map, void *key, u64 increment)
         return 0;                                                                                                      \
     }
 
-#define _increment_histogram(map, key, increment, max_bucket)                                                          \
+#define _increment_histogram(map, key, increment, max_bucket, increment_fn)                                            \
     if (key.bucket > max_bucket) {                                                                                     \
         key.bucket = max_bucket;                                                                                       \
     }                                                                                                                  \
                                                                                                                        \
-    increment_map(map, &key, 1);                                                                                       \
+    increment_fn(map, &key, 1);                                                                                        \
                                                                                                                        \
     if (increment > 0) {                                                                                               \
         key.bucket = max_bucket + 1;                                                                                   \
-        increment_map(map, &key, increment);                                                                           \
+        increment_fn(map, &key, increment);                                                                            \
     }
 
-#define increment_exp2_histogram(map, key, increment, max_bucket)                                                      \
+#define _increment_ex2_histogram(map, key, increment, max_bucket, increment_fn)                                        \
     key.bucket = log2l(increment);                                                                                     \
                                                                                                                        \
     if (key.bucket > max_bucket) {                                                                                     \
         key.bucket = max_bucket;                                                                                       \
     }                                                                                                                  \
                                                                                                                        \
-    _increment_histogram(map, key, increment, max_bucket);
+    _increment_histogram(map, key, increment, max_bucket, increment_fn);
 
-#define increment_exp2zero_histogram(map, key, increment, max_bucket)                                                  \
+#define increment_exp2_histogram(map, key, increment, max_bucket)                                                      \
+    _increment_ex2_histogram(map, key, increment, max_bucket, increment_map)
+
+#define increment_exp2_histogram_nosync(map, key, increment, max_bucket)                                               \
+    _increment_ex2_histogram(map, key, increment, max_bucket, increment_map_nosync)
+
+#define _increment_exp2zero_histogram(map, key, increment, max_bucket, increment_fn)                                   \
     if (increment == 0) {                                                                                              \
         key.bucket = 0;                                                                                                \
     } else {                                                                                                           \
         key.bucket = log2l(increment) + 1;                                                                             \
     }                                                                                                                  \
                                                                                                                        \
-    _increment_histogram(map, key, increment, max_bucket);
+    _increment_histogram(map, key, increment, max_bucket, increment_fn);
+
+#define increment_exp2zero_histogram(map, key, increment, max_bucket)                                                  \
+    _increment_exp2zero_histogram(map, key, increment, max_bucket, increment_map)
+
+#define increment_exp2zero_histogram_nosync(map, key, increment, max_bucket)                                           \
+    _increment_exp2zero_histogram(map, key, increment, max_bucket, increment_map_nosync)

--- a/examples/percpu-softirq.bpf.c
+++ b/examples/percpu-softirq.bpf.c
@@ -12,7 +12,7 @@ struct {
 SEC("tp_btf/softirq_entry")
 int BPF_PROG(softirq_entry, unsigned int vec_nr)
 {
-    increment_map(&softirqs_total, &vec_nr, 1);
+    increment_map_nosync(&softirqs_total, &vec_nr, 1);
     return 0;
 }
 

--- a/examples/softirq-latency.bpf.c
+++ b/examples/softirq-latency.bpf.c
@@ -98,7 +98,7 @@ int BPF_PROG(softirq_entry, unsigned int vec_nr)
 
     key.kind = vec_nr;
 
-    increment_exp2_histogram(&softirq_entry_latency_seconds, key, delta_us, MAX_LATENCY_SLOT);
+    increment_exp2_histogram_nosync(&softirq_entry_latency_seconds, key, delta_us, MAX_LATENCY_SLOT);
 
     // Allow raise timestamp to be set again
     *raise_ts_ptr = 0;
@@ -128,7 +128,7 @@ int BPF_PROG(softirq_exit, unsigned int vec_nr)
 
     key.kind = vec_nr;
 
-    increment_exp2_histogram(&softirq_service_latency_seconds, key, delta_us, MAX_LATENCY_SLOT);
+    increment_exp2_histogram_nosync(&softirq_service_latency_seconds, key, delta_us, MAX_LATENCY_SLOT);
 
     // Reset entry ts to prevent skipped entries to be counted at exit
     *entry_ts_ptr = 0;


### PR DESCRIPTION
THese are useful for percpu maps, as they allow to drop the locking on increment.

* Before: `25: (db) lock *(u64 *)(r0 +0) += r1`
* After: `24: (79) r1 = *(u64 *)(r0 +0)`

Full diff for xlated:

```diff
ivan@vm:~$ sudo bpftool prog dump xlated name softirq_entry | grep -v '^;' | sed 's/map\[.*\]/map[]/' | sed 's/^....:.//' > after.txt
ivan@vm:~$ sudo bpftool prog dump xlated name softirq_entry | grep -v '^;' | sed 's/map\[.*\]/map[]/' | sed 's/^....:.//' > before.txt
ivan@vm:~$ diff -rup before.txt after.txt
--- before.txt	2023-10-18 03:46:10.507608182 +0000
+++ after.txt	2023-10-18 03:45:51.562022297 +0000
@@ -19,8 +19,9 @@ int softirq_entry(unsigned long long * c
 (18) r1 = map[]
 (bf) r2 = r6
 (85) call htab_percpu_map_lookup_elem#244720
-(15) if r0 == 0x0 goto pc+2
-(b7) r1 = 1
-(db) lock *(u64 *)(r0 +0) += r1
+(15) if r0 == 0x0 goto pc+3
+(79) r1 = *(u64 *)(r0 +0)
+(07) r1 += 1
+(7b) *(u64 *)(r0 +0) = r1
 (b4) w0 = 0
 (95) exit
```

Full diff for jited:

```diff
ivan@vm:/mnt/linux/tools/bpf/bpftool$ sudo ./bpftool prog dump jited name softirq_entry | grep -v '^;' | grep -v "movk.x0" | sed 's/^....:.//' > after.txt
ivan@vm:/mnt/linux/tools/bpf/bpftool$ sudo ./bpftool prog dump jited name softirq_entry | grep -v '^;' | grep -v "movk.x0" | sed 's/^....:.//' > before.txt
ivan@vm:/mnt/linux/tools/bpf/bpftool$ diff -rup before.txt after.txt
--- before.txt	2023-10-18 04:38:34.404554692 +0000
+++ after.txt	2023-10-18 04:38:24.403621346 +0000
@@ -1,5 +1,5 @@
 int softirq_entry(unsigned long long * ctx):
-bpf_prog_0e306b10531b7f14_softirq_entry:
+bpf_prog_902733a94d79c04a_softirq_entry:
 add	x9, x30, #0x0
 nop
 paciasp
@@ -48,9 +48,10 @@ movk	x10, #0xffe9, lsl #32
 blr	x10
 add	x7, x0, #0x0
 cmp	x7, #0x0
-b.eq	0x000000e4  // b.none
-mov	x0, #0x1                   	// #1
-stadd	x0, [x7]
+b.eq	0x000000e8  // b.none
+ldr	x0, [x7]
+add	x0, x0, #0x1
+str	x0, [x7]
 mov	w7, #0x0                   	// #0
 add	sp, sp, #0x10
 ldp	x27, x28, [sp], #16
@@ -61,7 +62,6 @@ ldp	x29, x30, [sp], #16
 add	x0, x7, #0x0
 autiasp
 ret
-nop
 ldr	x10, 0x00000118
 br	x10
```

As expected, there's `stadd` in the sync version, which is a sync version of `add`:

* https://developer.arm.com/documentation/dui0801/h/A64-Data-Transfer-Instructions/STADD--STADDL--STADDL