### PR TITLE
Use percpu array in percpu-softirq

### DIFF
--- a/examples/percpu-softirq.bpf.c
+++ b/examples/percpu-softirq.bpf.c
@@ -3,7 +3,7 @@
 #include "maps.bpf.h"
 
 struct {
-    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
     __uint(max_entries, NR_SOFTIRQS);
     __type(key, u32);
     __type(value, u64);


### PR DESCRIPTION
We can get away with a direct access and no hashing this way.