### PR TITLE
Rebuild examples if any header changes

### DIFF
--- a/benchmark/probes/Makefile
+++ b/benchmark/probes/Makefile
@@ -6,10 +6,11 @@ ARCH := $(shell uname -m | sed -e 's/x86_64/x86/' -e 's/aarch64/arm64/')
 
 SRC = ${wildcard *.bpf.c}
 OBJ = ${patsubst %.bpf.c, %.bpf.o, $(SRC)}
+HDR = ${wildcard *.h}
 
 include ../../Makefile.libbpf
 
-$(OBJ): %.bpf.o: %.bpf.c benchmark.bpf.h ../../include/$(ARCH)/vmlinux.h $(LIBBPF_DEPS)
+$(OBJ): %.bpf.o: %.bpf.c $(HDR) ../../include/$(ARCH)/vmlinux.h $(LIBBPF_DEPS)
 	$(CC) -mcpu=v3 -g -O2 -Wall -Werror -D__TARGET_ARCH_$(ARCH) -I../../include/$(ARCH) $(LIBBPF_CFLAGS) -c -target bpf $< -o $@
 
 .PHONY: clean

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -6,6 +6,7 @@ ARCH := $(shell uname -m | sed -e 's/x86_64/x86/' -e 's/aarch64/arm64/')
 
 SRC = ${wildcard *.bpf.c}
 OBJ = ${patsubst %.bpf.c, %.bpf.o, $(SRC)}
+HDR = ${wildcard *.h}
 
 # From https://github.com/libbpf/libbpf-bootstrap/blob/a7c0f7e4a28/examples/c/Makefile#L34-L43
 # Get Clang's default includes on this system. We'll explicitly add these dirs
@@ -21,7 +22,7 @@ CLANG_BPF_SYS_INCLUDES = $(shell $(CC) -v -E - </dev/null 2>&1 \
 
 include ../Makefile.libbpf
 
-$(OBJ): %.bpf.o: %.bpf.c ../include/$(ARCH)/vmlinux.h $(LIBBPF_DEPS)
+$(OBJ): %.bpf.o: %.bpf.c $(HDR) ../include/$(ARCH)/vmlinux.h $(LIBBPF_DEPS)
 	$(CC) -mcpu=v3 -g -O2 -Wall -Werror -D__TARGET_ARCH_$(ARCH) $(CFLAGS) $(CLANG_BPF_SYS_INCLUDES) -I../include/$(ARCH) $(LIBBPF_CFLAGS) -c -target bpf $< -o $@
 
 .PHONY: clean


### PR DESCRIPTION
Without this changes to files like `map.bpf.h` are not picked up by make, which is a source of constant confusion when maps code is updated.