### PR TITLE
biolatency: Fix kernel version check.

### DIFF
--- a/examples/biolatency.bpf.c
+++ b/examples/biolatency.bpf.c
@@ -80,7 +80,7 @@ int block_rq_insert(struct bpf_raw_tracepoint_args *ctx)
      * from TP_PROTO(struct request_queue *q, struct request *rq)
      * to TP_PROTO(struct request *rq)
      */
-    if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 11, 0)) {
+    if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 10, 137)) {
         return trace_rq_start((void *) ctx->args[1]);
     } else {
         return trace_rq_start((void *) ctx->args[0]);
@@ -95,7 +95,7 @@ int block_rq_issue(struct bpf_raw_tracepoint_args *ctx)
      * from TP_PROTO(struct request_queue *q, struct request *rq)
      * to TP_PROTO(struct request *rq)
      */
-    if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 11, 0)) {
+    if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 10, 137)) {
         return trace_rq_start((void *) ctx->args[1]);
     } else {
         return trace_rq_start((void *) ctx->args[0]);


### PR DESCRIPTION
The tracepoint definition change in v5.11-rc1 mentioned in the biolatency example program seems to have been [backported into v5.10.137](https://elixir.bootlin.com/linux/v5.10.137/source/include/trace/events/block.h#L206).
This small fix allows the program to load and work on kernels between v5.10.137 and v5.11. I deem this PR small enough not to have a related issue opened.