### PR TITLE
Simplify bpf header includes

### DIFF
--- a/benchmark/probes/benchmark.bpf.h
+++ b/benchmark/probes/benchmark.bpf.h
@@ -1,5 +1,4 @@
 #include "vmlinux.h"
-#include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 
 #if defined(__TARGET_ARCH_x86)

--- a/examples/accept-latency.bpf.c
+++ b/examples/accept-latency.bpf.c
@@ -1,8 +1,6 @@
 #include <vmlinux.h>
-#include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_core_read.h>
-#include "bits.bpf.h"
 #include "maps.bpf.h"
 
 // 27 buckets for latency, max range is 33.6s .. 67.1s

--- a/examples/biolatency.bpf.c
+++ b/examples/biolatency.bpf.c
@@ -1,7 +1,6 @@
 #include <vmlinux.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
-#include "bits.bpf.h"
 #include "maps.bpf.h"
 
 // Max number of disks we expect to see on the host

--- a/examples/cachestat.bpf.c
+++ b/examples/cachestat.bpf.c
@@ -1,5 +1,4 @@
 #include <vmlinux.h>
-#include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_core_read.h>
 #include "maps.bpf.h"

--- a/examples/cfs-throttling.bpf.c
+++ b/examples/cfs-throttling.bpf.c
@@ -1,6 +1,5 @@
 #include <vmlinux.h>
 #include <bpf/bpf_tracing.h>
-#include "bits.bpf.h"
 #include "maps.bpf.h"
 
 // 21 buckets for latency, max range is 0.5s .. 1.0s

--- a/examples/cgroup.bpf.c
+++ b/examples/cgroup.bpf.c
@@ -1,6 +1,5 @@
 #include <vmlinux.h>
 #include <bpf/bpf_tracing.h>
-#include "bits.bpf.h"
 #include "maps.bpf.h"
 
 struct {

--- a/examples/llcstat.bpf.c
+++ b/examples/llcstat.bpf.c
@@ -1,5 +1,4 @@
 #include <vmlinux.h>
-#include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 #include "maps.bpf.h"
 

--- a/examples/maps.bpf.h
+++ b/examples/maps.bpf.h
@@ -1,3 +1,5 @@
+#include "bits.bpf.h"
+
 #define lookup_or_zero_init_key(map, key, into)                                                                        \
     u64 zero = 0;                                                                                                      \
                                                                                                                        \

--- a/examples/oomkill.bpf.c
+++ b/examples/oomkill.bpf.c
@@ -1,5 +1,4 @@
 #include <vmlinux.h>
-#include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_core_read.h>
 

--- a/examples/shrinklat.bpf.c
+++ b/examples/shrinklat.bpf.c
@@ -1,6 +1,5 @@
 #include <vmlinux.h>
 #include <bpf/bpf_helpers.h>
-#include "bits.bpf.h"
 #include "maps.bpf.h"
 
 // 27 buckets for latency, max range is 33.6s .. 67.1s

--- a/examples/softirq-latency-net-rx.bpf.c
+++ b/examples/softirq-latency-net-rx.bpf.c
@@ -1,6 +1,5 @@
 #include <vmlinux.h>
 #include <bpf/bpf_tracing.h>
-#include "bits.bpf.h"
 #include "maps.bpf.h"
 
 // Loosely based on https://github.com/xdp-project/xdp-project/blob/master/areas/latency/softirq_net_latency.bt

--- a/examples/softirq-latency.bpf.c
+++ b/examples/softirq-latency.bpf.c
@@ -1,6 +1,5 @@
 #include <vmlinux.h>
 #include <bpf/bpf_tracing.h>
-#include "bits.bpf.h"
 #include "maps.bpf.h"
 
 // Loosely based on https://github.com/xdp-project/xdp-project/blob/master/areas/latency/softirq_net_latency.bt

--- a/examples/tcp-syn-backlog-exp2zero.bpf.c
+++ b/examples/tcp-syn-backlog-exp2zero.bpf.c
@@ -1,8 +1,6 @@
 #include <vmlinux.h>
-#include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_core_read.h>
-#include "bits.bpf.h"
 #include "maps.bpf.h"
 
 // 17 buckets, max range is 32k..64k

--- a/examples/tcp-syn-backlog.bpf.c
+++ b/examples/tcp-syn-backlog.bpf.c
@@ -1,5 +1,4 @@
 #include <vmlinux.h>
-#include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_core_read.h>
 #include "maps.bpf.h"

--- a/examples/unix-socket-backlog.bpf.c
+++ b/examples/unix-socket-backlog.bpf.c
@@ -1,7 +1,5 @@
 #include <vmlinux.h>
-#include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
-#include "bits.bpf.h"
 #include "maps.bpf.h"
 
 // 17 buckets for backlog sizes, max range is 64k..128k

--- a/examples/uprobe.bpf.c
+++ b/examples/uprobe.bpf.c
@@ -1,6 +1,5 @@
 #include <vmlinux.h>
 #include <bpf/bpf_helpers.h>
-#include "bits.bpf.h"
 #include "maps.bpf.h"
 
 struct {

--- a/examples/usdt.bpf.c
+++ b/examples/usdt.bpf.c
@@ -1,7 +1,6 @@
 #include <vmlinux.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/usdt.bpf.h>
-#include "bits.bpf.h"
 #include "maps.bpf.h"
 
 struct call_t {


### PR DESCRIPTION
* Do not include `bpf_helpers.h` if `bpf_tracing.h` is included (unnecessary)
* Include `bits.bpf.h` from `maps.bpf.h` where it is used