### PR TITLE
Updated kernel version for biolatency from 5.10.137 to 5.10.178

### DIFF
--- a/examples/biolatency.bpf.c
+++ b/examples/biolatency.bpf.c
@@ -79,7 +79,7 @@ int block_rq_insert(struct bpf_raw_tracepoint_args *ctx)
      * from TP_PROTO(struct request_queue *q, struct request *rq)
      * to TP_PROTO(struct request *rq)
      */
-    if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 10, 137)) {
+    if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 10, 178)) {
         return trace_rq_start((void *) ctx->args[1]);
     } else {
         return trace_rq_start((void *) ctx->args[0]);
@@ -94,7 +94,7 @@ int block_rq_issue(struct bpf_raw_tracepoint_args *ctx)
      * from TP_PROTO(struct request_queue *q, struct request *rq)
      * to TP_PROTO(struct request *rq)
      */
-    if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 10, 137)) {
+    if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 10, 178)) {
         return trace_rq_start((void *) ctx->args[1]);
     } else {
         return trace_rq_start((void *) ctx->args[0]);


### PR DESCRIPTION
With original version check for 5.10.137, ebpf_exporter fails with 'Invalid argument' in my environment running 5.10.178 kernel. Adding @ntnx-aleksa for fyi since he made the last update in commit [5511eae](https://github.com/cloudflare/ebpf_exporter/commit/5511eaeeea6745a2508e2786b586c865444a81f6)