### PR TITLE
Suppress BTF warning in shrinklat due to type mismatch

### DIFF
--- a/examples/shrinklat.bpf.c
+++ b/examples/shrinklat.bpf.c
@@ -19,7 +19,7 @@ struct {
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
     __uint(max_entries, MAX_LATENCY_SLOT + 1);
-    __type(key, struct key_t);
+    __type(key, u32); // struct key_t in reality, but btf gets confused and logs a warning
     __type(value, u64);
 } shrink_node_latency_seconds SEC(".maps");
 


### PR DESCRIPTION
The layout is the same, but BTF is confused when u32 is wrapped in a struct:

```
libbpf [warn]: libbpf: Error in bpf_create_map_xattr(shrink_node_latency_seconds):Invalid argument(-22). Retrying without BTF.
```