### PR TITLE
Output diff from clang-format-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ jsonschema:
 
 .PHONY: clang-format-check
 clang-format-check:
-	clang-format --dry-run --verbose -Werror $(CLANG_FORMAT_FILES)
+	./scripts/clang-format-check.sh $(CLANG_FORMAT_FILES)
 
 .PHONY: test
 test: $(LIBBPF_DEPS)

--- a/scripts/clang-format-check.sh
+++ b/scripts/clang-format-check.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+exit_status=0
+
+for file in "$@"; do
+    ret=$(clang-format --dry-run --verbose -Werror "${file}"; echo $?)
+
+    if [ "${ret}" != 0 ]; then
+        diff --color=always --unified --show-c-function "${file}" <(clang-format --verbose -Werror "${file}") || true
+
+        exit_status=$ret
+    fi
+done
+
+exit "${exit_status}"


### PR DESCRIPTION
Example output:

```
ivan@vm:~/projects/ebpf_exporter$ make clang-format-check
./scripts/clang-format-check.sh examples/accept-latency.bpf.c examples/biolatency.bpf.c examples/bpf-jit.bpf.c examples/cachestat.bpf.c examples/cfs-throttling.bpf.c examples/cgroup.bpf.c examples/icmp-ip.bpf.c examples/kfree_skb.bpf.c examples/kstack.bpf.c examples/llcstat.bpf.c examples/oomkill.bpf.c examples/pci.bpf.c examples/percpu-softirq.bpf.c examples/raw-tracepoints.bpf.c examples/shrinklat.bpf.c examples/softirq-latency.bpf.c examples/softirq-latency-net-rx.bpf.c examples/syscalls.bpf.c examples/tcp-retransmit.bpf.c examples/tcp-syn-backlog.bpf.c examples/tcp-syn-backlog-exp2zero.bpf.c examples/tcp-window-clamps.bpf.c examples/timers.bpf.c examples/udp-drops.bpf.c examples/unix-socket-backlog.bpf.c examples/uprobe.bpf.c examples/usdt.bpf.c examples/xdp.bpf.c examples/bits.bpf.h examples/maps.bpf.h examples/regs-ip.bpf.h benchmark/probes/fentry-complex.bpf.c benchmark/probes/fentry-empty.bpf.c benchmark/probes/fentry-simple.bpf.c benchmark/probes/kprobe-complex.bpf.c benchmark/probes/kprobe-empty.bpf.c benchmark/probes/kprobe-simple.bpf.c benchmark/probes/tracepoint-complex.bpf.c benchmark/probes/tracepoint-empty.bpf.c benchmark/probes/tracepoint-simple.bpf.c benchmark/probes/benchmark.bpf.h
Formatting [1/1] examples/accept-latency.bpf.c
Formatting [1/1] examples/biolatency.bpf.c
Formatting [1/1] examples/bpf-jit.bpf.c
Formatting [1/1] examples/cachestat.bpf.c
Formatting [1/1] examples/cfs-throttling.bpf.c
Formatting [1/1] examples/cgroup.bpf.c
Formatting [1/1] examples/icmp-ip.bpf.c
Formatting [1/1] examples/kfree_skb.bpf.c
Formatting [1/1] examples/kstack.bpf.c
Formatting [1/1] examples/llcstat.bpf.c
Formatting [1/1] examples/oomkill.bpf.c
Formatting [1/1] examples/pci.bpf.c
Formatting [1/1] examples/percpu-softirq.bpf.c
Formatting [1/1] examples/raw-tracepoints.bpf.c
Formatting [1/1] examples/shrinklat.bpf.c
Formatting [1/1] examples/softirq-latency.bpf.c
Formatting [1/1] examples/softirq-latency-net-rx.bpf.c
Formatting [1/1] examples/syscalls.bpf.c
Formatting [1/1] examples/tcp-retransmit.bpf.c
examples/tcp-retransmit.bpf.c:8:19: error: code should be clang-formatted [-Wclang-format-violations]
                  ^
examples/tcp-retransmit.bpf.c:9:12: error: code should be clang-formatted [-Wclang-format-violations]
           ^
examples/tcp-retransmit.bpf.c:10:16: error: code should be clang-formatted [-Wclang-format-violations]
               ^
examples/tcp-retransmit.bpf.c:11:17: error: code should be clang-formatted [-Wclang-format-violations]
                ^^^^^^^^
examples/tcp-retransmit.bpf.c:13:20: error: code should be clang-formatted [-Wclang-format-violations]
struct ipv4_key_t {
                   ^
examples/tcp-retransmit.bpf.c:14:12: error: code should be clang-formatted [-Wclang-format-violations]
        u32 saddr;
                  ^
examples/tcp-retransmit.bpf.c:15:12: error: code should be clang-formatted [-Wclang-format-violations]
        u32 daddr;
                  ^
examples/tcp-retransmit.bpf.c:16:14: error: code should be clang-formatted [-Wclang-format-violations]
        __u16 sport;
                    ^
examples/tcp-retransmit.bpf.c:17:14: error: code should be clang-formatted [-Wclang-format-violations]
        __u16 dport;
                    ^
examples/tcp-retransmit.bpf.c:21:20: error: code should be clang-formatted [-Wclang-format-violations]
struct ipv6_key_t {
                   ^
examples/tcp-retransmit.bpf.c:22:15: error: code should be clang-formatted [-Wclang-format-violations]
        u8 saddr[16];
                     ^
examples/tcp-retransmit.bpf.c:23:15: error: code should be clang-formatted [-Wclang-format-violations]
        u8 daddr[16];
                     ^
examples/tcp-retransmit.bpf.c:24:14: error: code should be clang-formatted [-Wclang-format-violations]
        __u16 sport;
                    ^
examples/tcp-retransmit.bpf.c:25:14: error: code should be clang-formatted [-Wclang-format-violations]
        __u16 dport;
                    ^
examples/tcp-retransmit.bpf.c:29:9: error: code should be clang-formatted [-Wclang-format-violations]
struct {
        ^
examples/tcp-retransmit.bpf.c:30:38: error: code should be clang-formatted [-Wclang-format-violations]
        __uint(type, BPF_MAP_TYPE_LRU_HASH);
                                            ^
examples/tcp-retransmit.bpf.c:31:35: error: code should be clang-formatted [-Wclang-format-violations]
        __uint(max_entries, MAX_ENTRIES);
                                         ^
examples/tcp-retransmit.bpf.c:32:33: error: code should be clang-formatted [-Wclang-format-violations]
        __type(key, struct ipv4_key_t);
                                       ^
examples/tcp-retransmit.bpf.c:36:9: error: code should be clang-formatted [-Wclang-format-violations]
struct {
        ^
examples/tcp-retransmit.bpf.c:37:38: error: code should be clang-formatted [-Wclang-format-violations]
        __uint(type, BPF_MAP_TYPE_LRU_HASH);
                                            ^
examples/tcp-retransmit.bpf.c:38:35: error: code should be clang-formatted [-Wclang-format-violations]
        __uint(max_entries, MAX_ENTRIES);
                                         ^
examples/tcp-retransmit.bpf.c:39:33: error: code should be clang-formatted [-Wclang-format-violations]
        __type(key, struct ipv6_key_t);
                                       ^
examples/tcp-retransmit.bpf.c:44:2: error: code should be clang-formatted [-Wclang-format-violations]
{
 ^
examples/tcp-retransmit.bpf.c:45:44: error: code should be clang-formatted [-Wclang-format-violations]
        __u32 family = sk->__sk_common.skc_family;
                                                  ^
examples/tcp-retransmit.bpf.c:47:26: error: code should be clang-formatted [-Wclang-format-violations]
        if (family == AF_INET) {
                                ^
examples/tcp-retransmit.bpf.c:48:25: error: code should be clang-formatted [-Wclang-format-violations]
                struct ipv4_key_t key;
                                      ^
examples/tcp-retransmit.bpf.c:50:45: error: code should be clang-formatted [-Wclang-format-violations]
                key.saddr = sk->__sk_common.skc_rcv_saddr;
                                                          ^
examples/tcp-retransmit.bpf.c:51:41: error: code should be clang-formatted [-Wclang-format-violations]
                key.daddr = sk->__sk_common.skc_daddr;
                                                      ^
examples/tcp-retransmit.bpf.c:52:39: error: code should be clang-formatted [-Wclang-format-violations]
                key.sport = sk->__sk_common.skc_num;
                                                    ^
examples/tcp-retransmit.bpf.c:53:41: error: code should be clang-formatted [-Wclang-format-violations]
                key.dport = sk->__sk_common.skc_dport;
                                                      ^
examples/tcp-retransmit.bpf.c:54:19: error: code should be clang-formatted [-Wclang-format-violations]
                key.type = type;
                                ^
examples/tcp-retransmit.bpf.c:56:62: error: code should be clang-formatted [-Wclang-format-violations]
                increment_map(&tcp_retransmit_ipv4_packets_total, &key, 1);
                                                                           ^
examples/tcp-retransmit.bpf.c:58:34: error: code should be clang-formatted [-Wclang-format-violations]
        } else if (family == AF_INET6) {
                                        ^
examples/tcp-retransmit.bpf.c:59:25: error: code should be clang-formatted [-Wclang-format-violations]
                struct ipv6_key_t key;
                                      ^
examples/tcp-retransmit.bpf.c:61:90: error: code should be clang-formatted [-Wclang-format-violations]
                memcpy(key.saddr, sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32, sizeof(key.saddr));
                                                                                                       ^
examples/tcp-retransmit.bpf.c:62:86: error: code should be clang-formatted [-Wclang-format-violations]
                memcpy(key.daddr, sk->__sk_common.skc_v6_daddr.in6_u.u6_addr32, sizeof(key.daddr));
                                                                                                   ^
examples/tcp-retransmit.bpf.c:63:39: error: code should be clang-formatted [-Wclang-format-violations]
                key.sport = sk->__sk_common.skc_num;
                                                    ^
examples/tcp-retransmit.bpf.c:64:41: error: code should be clang-formatted [-Wclang-format-violations]
                key.dport = sk->__sk_common.skc_dport;
                                                      ^
examples/tcp-retransmit.bpf.c:65:19: error: code should be clang-formatted [-Wclang-format-violations]
                key.type = type;
                                ^
examples/tcp-retransmit.bpf.c:67:62: error: code should be clang-formatted [-Wclang-format-violations]
                increment_map(&tcp_retransmit_ipv6_packets_total, &key, 1);
                                                                           ^
examples/tcp-retransmit.bpf.c:74:2: error: code should be clang-formatted [-Wclang-format-violations]
{
 ^
examples/tcp-retransmit.bpf.c:80:2: error: code should be clang-formatted [-Wclang-format-violations]
{
 ^
Formatting [1/1] examples/tcp-retransmit.bpf.c
--- examples/tcp-retransmit.bpf.c	2023-11-18 17:42:48.833176258 +0000
+++ /dev/fd/63	2023-11-18 17:51:42.638700449 +0000
@@ -5,80 +5,80 @@
 #include "maps.bpf.h"

 #define MAX_ENTRIES 8192
-#define RETRANSMIT  1
-#define TLP         2
-#define AF_INET		2
-#define AF_INET6	10
+#define RETRANSMIT 1
+#define TLP 2
+#define AF_INET 2
+#define AF_INET6 10

 struct ipv4_key_t {
-	u32 saddr;
-	u32 daddr;
-	__u16 sport;
-	__u16 dport;
-	u32 type;
+    u32 saddr;
+    u32 daddr;
+    __u16 sport;
+    __u16 dport;
+    u32 type;
 };

 struct ipv6_key_t {
-	u8 saddr[16];
-	u8 daddr[16];
-	__u16 sport;
-	__u16 dport;
-	u32 type;
+    u8 saddr[16];
+    u8 daddr[16];
+    __u16 sport;
+    __u16 dport;
+    u32 type;
 };

 struct {
-	__uint(type, BPF_MAP_TYPE_LRU_HASH);
-	__uint(max_entries, MAX_ENTRIES);
-	__type(key, struct ipv4_key_t);
-	__type(value, u64);
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(max_entries, MAX_ENTRIES);
+    __type(key, struct ipv4_key_t);
+    __type(value, u64);
 } tcp_retransmit_ipv4_packets_total SEC(".maps");

 struct {
-	__uint(type, BPF_MAP_TYPE_LRU_HASH);
-	__uint(max_entries, MAX_ENTRIES);
-	__type(key, struct ipv6_key_t);
-	__type(value, u64);
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(max_entries, MAX_ENTRIES);
+    __type(key, struct ipv6_key_t);
+    __type(value, u64);
 } tcp_retransmit_ipv6_packets_total SEC(".maps");

 static int trace_event(const struct sock *sk, u32 type)
 {
-	__u32 family = sk->__sk_common.skc_family;
+    __u32 family = sk->__sk_common.skc_family;

-	if (family == AF_INET) {
-		struct ipv4_key_t key;
+    if (family == AF_INET) {
+        struct ipv4_key_t key;

-		key.saddr = sk->__sk_common.skc_rcv_saddr;
-		key.daddr = sk->__sk_common.skc_daddr;
-		key.sport = sk->__sk_common.skc_num;
-		key.dport = sk->__sk_common.skc_dport;
-		key.type = type;
-
-		increment_map(&tcp_retransmit_ipv4_packets_total, &key, 1);
-
-	} else if (family == AF_INET6) {
-		struct ipv6_key_t key;
-
-		memcpy(key.saddr, sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32, sizeof(key.saddr));
-		memcpy(key.daddr, sk->__sk_common.skc_v6_daddr.in6_u.u6_addr32, sizeof(key.daddr));
-		key.sport = sk->__sk_common.skc_num;
-		key.dport = sk->__sk_common.skc_dport;
-		key.type = type;
+        key.saddr = sk->__sk_common.skc_rcv_saddr;
+        key.daddr = sk->__sk_common.skc_daddr;
+        key.sport = sk->__sk_common.skc_num;
+        key.dport = sk->__sk_common.skc_dport;
+        key.type = type;
+
+        increment_map(&tcp_retransmit_ipv4_packets_total, &key, 1);
+
+    } else if (family == AF_INET6) {
+        struct ipv6_key_t key;
+
+        memcpy(key.saddr, sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32, sizeof(key.saddr));
+        memcpy(key.daddr, sk->__sk_common.skc_v6_daddr.in6_u.u6_addr32, sizeof(key.daddr));
+        key.sport = sk->__sk_common.skc_num;
+        key.dport = sk->__sk_common.skc_dport;
+        key.type = type;

-		increment_map(&tcp_retransmit_ipv6_packets_total, &key, 1);
-	}
+        increment_map(&tcp_retransmit_ipv6_packets_total, &key, 1);
+    }
     return 0;
 }

 SEC("fentry/tcp_send_loss_probe")
 int BPF_PROG(tcp_send_loss_probe, struct sock *sk)
 {
-	return trace_event(sk, TLP);
+    return trace_event(sk, TLP);
 }

 SEC("fentry/tcp_retransmit_skb")
 int BPF_PROG(tcp_retransmit_skb, struct sock *sk)
 {
-	return trace_event(sk, RETRANSMIT);
+    return trace_event(sk, RETRANSMIT);
 }

 char LICENSE[] SEC("license") = "GPL";
Formatting [1/1] examples/tcp-syn-backlog.bpf.c
Formatting [1/1] examples/tcp-syn-backlog-exp2zero.bpf.c
Formatting [1/1] examples/tcp-window-clamps.bpf.c
Formatting [1/1] examples/timers.bpf.c
Formatting [1/1] examples/udp-drops.bpf.c
Formatting [1/1] examples/unix-socket-backlog.bpf.c
Formatting [1/1] examples/uprobe.bpf.c
Formatting [1/1] examples/usdt.bpf.c
Formatting [1/1] examples/xdp.bpf.c
Formatting [1/1] examples/bits.bpf.h
Formatting [1/1] examples/maps.bpf.h
Formatting [1/1] examples/regs-ip.bpf.h
Formatting [1/1] benchmark/probes/fentry-complex.bpf.c
Formatting [1/1] benchmark/probes/fentry-empty.bpf.c
Formatting [1/1] benchmark/probes/fentry-simple.bpf.c
Formatting [1/1] benchmark/probes/kprobe-complex.bpf.c
Formatting [1/1] benchmark/probes/kprobe-empty.bpf.c
Formatting [1/1] benchmark/probes/kprobe-simple.bpf.c
Formatting [1/1] benchmark/probes/tracepoint-complex.bpf.c
Formatting [1/1] benchmark/probes/tracepoint-empty.bpf.c
Formatting [1/1] benchmark/probes/tracepoint-simple.bpf.c
Formatting [1/1] benchmark/probes/benchmark.bpf.h
make: *** [Makefile:46: clang-format-check] Error 1
```