### PR TITLE
Add interface name decoder

### DIFF
--- a/.vscode/config-schema.yaml
+++ b/.vscode/config-schema.yaml
@@ -97,6 +97,7 @@ definitions:
                 enum:
                   - cgroup
                   - dname
+                  - ifname
                   - inet_ip
                   - kstack
                   - ksym

--- a/README.md
+++ b/README.md
@@ -566,6 +566,11 @@ into a human readable string representing cgroup path, like:
 
 * `/sys/fs/cgroup/system.slice/ssh.service`
 
+#### ifname
+
+Ifname decoder takes a network interface index and converts it into its
+name like `eth0`.
+
 #### `dname`
 
 Dname decoder read DNS qname from string in wire format, then decode

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -41,6 +41,7 @@ func NewSet() (*Set, error) {
 		decoders: map[string]Decoder{
 			"cgroup":       cgroup,
 			"dname":        &Dname{},
+			"ifname":       &IfName{},
 			"inet_ip":      &InetIP{},
 			"kstack":       &KStack{ksym},
 			"ksym":         &KSym{ksym},

--- a/decoder/ifname.go
+++ b/decoder/ifname.go
@@ -1,0 +1,42 @@
+package decoder
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/cloudflare/ebpf_exporter/v2/config"
+	"github.com/cloudflare/ebpf_exporter/v2/util"
+)
+
+// IfName is a decoder that transforms a network interface index into its name.
+type IfName struct {
+	cache map[uint32][]byte
+}
+
+// Decode transforms a network interface index into a name like "ens10".
+func (i *IfName) Decode(in []byte, _ config.Decoder) ([]byte, error) {
+	if i.cache == nil {
+		i.cache = make(map[uint32][]byte)
+	}
+
+	// Interface index is a uint32.
+	idx := util.GetHostByteOrder().Uint32(in[0:4])
+
+	if name, ok := i.cache[idx]; ok {
+		return name, nil
+	}
+
+	iface, err := net.InterfaceByIndex(int(idx))
+	if err != nil {
+		// The interface might have been deleted since the metric was last
+		// written. Unfortunately, in case the interface index is not in use
+		// [net.InterfaceByIndex] does not return a unique error value that can
+		// be compared with.
+		return []byte(fmt.Sprintf("unknown:%d", idx)), nil
+	}
+
+	name := []byte(iface.Name)
+	i.cache[idx] = name
+
+	return name, nil
+}

--- a/decoder/ifname_test.go
+++ b/decoder/ifname_test.go
@@ -1,0 +1,46 @@
+package decoder
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cloudflare/ebpf_exporter/v2/config"
+)
+
+func TestIfNameDecoder(t *testing.T) {
+	cache := map[uint32][]byte{
+		uint32(1):          []byte("lo"),
+		uint32(2734686214): []byte("eth42"),
+	}
+
+	cases := []struct {
+		in  []byte
+		out []byte
+	}{
+		{
+			in:  []byte{0x1, 0x0, 0x0, 0x0},
+			out: []byte("lo"),
+		},
+		{
+			in:  []byte{0x6, 0x0, 0x0, 0xa3},
+			out: []byte("eth42"),
+		},
+		{
+			in:  []byte{0x0, 0x0, 0x0, 0x0},
+			out: []byte("unknown:0"),
+		},
+	}
+
+	for _, c := range cases {
+		d := &IfName{cache: cache}
+
+		out, err := d.Decode(c.in, config.Decoder{})
+		if err != nil {
+			t.Errorf("Error decoding %#v: %v", c.in, err)
+		}
+
+		if !bytes.Equal(out, c.out) {
+			t.Errorf("Expected %s, got %s", c.out, out)
+		}
+	}
+}

--- a/examples/inet-frags.bpf.c
+++ b/examples/inet-frags.bpf.c
@@ -1,0 +1,39 @@
+#include <vmlinux.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+#include "maps.bpf.h"
+
+struct inet_frags_key_t {
+    u32 ifindex;
+    u8 ip_version;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(max_entries, 64);
+    __type(key, struct inet_frags_key_t);
+    __type(value, u64);
+} inet_frags_total SEC(".maps");
+
+static __always_inline void increment_map_for_skb(void *map, struct sk_buff *skb)
+{
+    void *skb_head = BPF_CORE_READ(skb, head);
+    u16 skb_l3_off = BPF_CORE_READ(skb, network_header);
+
+    struct iphdr *iph = (struct iphdr *) (skb_head + skb_l3_off);
+    struct inet_frags_key_t key = { 0 };
+
+    key.ip_version = BPF_CORE_READ_BITFIELD_PROBED(iph, version);
+    key.ifindex = BPF_CORE_READ(skb, skb_iif);
+
+    increment_map(map, &key, 1);
+}
+
+SEC("kprobe/inet_frag_queue_insert")
+int BPF_KPROBE(inet_frag_queue_insert, struct inet_frag_queue *q, struct sk_buff *skb, int offset)
+{
+    increment_map_for_skb(&inet_frags_total, skb);
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/examples/inet-frags.yaml
+++ b/examples/inet-frags.yaml
@@ -1,0 +1,13 @@
+metrics:
+  counters:
+    - name: inet_frags_total
+      help: Netfilter inet fragments per interface and IP version
+      labels:
+        - name: interface
+          size: 4
+          decoders:
+            - name: ifname
+        - name: ip_version
+          size: 4
+          decoders:
+            - name: uint


### PR DESCRIPTION
Add decoder for decoding an network interface index into its name, if the interface is still present.

    ebpf_exporter_inet_frags_queue_insert{interface="eth0"} 2