### PR TITLE
Add decoder cache

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -1,6 +1,7 @@
 package decoder
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"sync"
@@ -23,6 +24,7 @@ type Decoder interface {
 type Set struct {
 	mu       sync.Mutex
 	decoders map[string]Decoder
+	cache    map[string][]string
 }
 
 // NewSet creates a Set with all known decoders
@@ -56,6 +58,7 @@ func NewSet() (*Set, error) {
 			"syscall":      &Syscall{},
 			"uint":         &UInt{},
 		},
+		cache: map[string][]string{},
 	}, nil
 }
 
@@ -87,6 +90,23 @@ func (s *Set) Decode(in []byte, label config.Label) ([]byte, error) {
 // DecodeLabels transforms eBPF map key bytes into a list of label values
 // according to configuration
 func (s *Set) DecodeLabels(in []byte, labels []config.Label) ([]string, error) {
+	cacheKey := hex.EncodeToString(in)
+	if cached, ok := s.cache[cacheKey]; ok {
+		return cached, nil
+	}
+
+	values, err := s.decodeLabels(in, labels)
+	if err != nil {
+		return nil, err
+	}
+
+	s.cache[cacheKey] = values
+
+	return values, nil
+}
+
+// decodeLabels is the inner function of DecodeLabels without any caching
+func (s *Set) decodeLabels(in []byte, labels []config.Label) ([]string, error) {
 	values := make([]string, len(labels))
 
 	off := uint(0)

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -151,6 +151,77 @@ func TestDecodeLabels(t *testing.T) {
 	}
 }
 
+func BenchmarkCache(b *testing.B) {
+	in := []byte{
+		0x8, 0xab, 0xce, 0xef,
+		0xde, 0xad,
+		0xbe, 0xef,
+		0x8, 0xab, 0xce, 0xef, 0x8, 0xab, 0xce, 0xef,
+	}
+
+	labels := []config.Label{
+		{
+			Name: "number1",
+			Size: 4,
+			Decoders: []config.Decoder{
+				{
+					Name: "uint",
+				},
+			},
+		},
+		{
+			Name: "number2",
+			Size: 2,
+			Decoders: []config.Decoder{
+				{
+					Name: "uint",
+				},
+			},
+		},
+		{
+			Name: "number3",
+			Size: 2,
+			Decoders: []config.Decoder{
+				{
+					Name: "uint",
+				},
+			},
+		},
+		{
+			Name: "number4",
+			Size: 8,
+			Decoders: []config.Decoder{
+				{
+					Name: "uint",
+				},
+			},
+		},
+	}
+
+	s, err := NewSet()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("direct", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, err := s.decodeLabels(in, labels)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("cached", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, err := s.DecodeLabels(in, labels)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
 func zeroPaddedString(in string, size int) []byte {
 	if len(in) > size {
 		panic(fmt.Sprintf("string %q is longer than requested size %d", in, size))


### PR DESCRIPTION
Two commits:

---

### Add decoder cache

When using percpu maps on large machines, one can find themself decoding the same set of inputs to the same set of values over and over again.

Given that the configuration is static and inputs generally do not disappear, it is a good idea to add a cache to speed up decoding.

Unfortunately, Go does not allow having `[]byte` as a map key, so we have to convert the cache key to a string, making it a little bit more expensive that it could've been otherwise.

Here's a benchmark:

```
goos: linux
goarch: arm64
pkg: github.com/cloudflare/ebpf_exporter/v2/decoder
BenchmarkCache/direct-10                 2328188               517.7 ns/op           264 B/op         17 allocs/op
BenchmarkCache/cached-10                23191784                48.9 ns/op            64 B/op          2 allocs/op
```

---

### Improve cache efficiency in decoder

Instead of converting `[]byte` to `string` to use it in a map key, we can hash `[]byte` to use as a key and make sure that there are no collisions as a result of this. This is quite a bit faster (before and after):

```
BenchmarkCache/cached-10             23694093            49.04 ns/op          64 B/op           2 allocs/op
BenchmarkCache/cached-10            132218238             9.29 ns/op           0 B/op           0 allocs/op
```