### PR TITLE
Partition decoder cache by name

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -438,7 +438,7 @@ func (e *Exporter) mapValues(module *libbpfgo.Module, name string, labels []conf
 			raw = raw[4:]
 		}
 
-		metricValues[i].labels, err = e.decoders.DecodeLabels(raw, labels)
+		metricValues[i].labels, err = e.decoders.DecodeLabels(raw, name, labels)
 		if err != nil {
 			if err == decoder.ErrSkipLabelSet {
 				continue

--- a/exporter/perf_event_array.go
+++ b/exporter/perf_event_array.go
@@ -43,7 +43,7 @@ func newPerfEventArraySink(decoders *decoder.Set, module *libbpfgo.Module, count
 				validDataSize += labelConfig.Size
 			}
 
-			labelValues, err := decoders.DecodeLabels(rawBytes[:validDataSize], sink.counterConfig.Labels)
+			labelValues, err := decoders.DecodeLabels(rawBytes[:validDataSize], counterConfig.Name, sink.counterConfig.Labels)
 			if err != nil {
 				if err == decoder.ErrSkipLabelSet {
 					continue


### PR DESCRIPTION
Sometimes the same input means different things for different `[]config.Label`, but our cache implementation was not partitioning cache. With this commit we partition the cache by incoming `name` to account for that, with `name` coming from the map name, which is unique across all loaded programs.