### PR TITLE
Split metrics (cached) and tracing (uncached) label decoding

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -85,9 +85,10 @@ func (s *Set) decode(in []byte, label config.Label) ([]byte, error) {
 	return result, nil
 }
 
-// DecodeLabels transforms eBPF map key bytes into a list of label values
-// according to configuration (different label sets require different names)
-func (s *Set) DecodeLabels(in []byte, name string, labels []config.Label) ([]string, error) {
+// DecodeLabelsForMetrics transforms eBPF map key bytes into a list of label values
+// according to configuration (different label sets require different names).
+// This decoder method variant does caching and is suitable for metrics.
+func (s *Set) DecodeLabelsForMetrics(in []byte, name string, labels []config.Label) ([]string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -111,6 +112,16 @@ func (s *Set) DecodeLabels(in []byte, name string, labels []config.Label) ([]str
 	cache[string(in)] = values
 
 	return values, nil
+}
+
+// DecodeLabelsForTracing transforms eBPF map key bytes into a list of label values
+// according to configuration (different label sets require different names).
+// This decoder method variant does not do caching and is suitable for tracing.
+func (s *Set) DecodeLabelsForTracing(in []byte, labels []config.Label) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.decodeLabels(in, labels)
 }
 
 // decodeLabels is the inner function of DecodeLabels without any caching

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -127,7 +127,7 @@ func TestDecodeLabels(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		out, err := s.DecodeLabels(c.in, fmt.Sprintf("test:%d", i), c.labels)
+		out, err := s.DecodeLabelsForMetrics(c.in, fmt.Sprintf("test:%d", i), c.labels)
 		if c.err {
 			if err == nil {
 				t.Errorf("Expected error for input %#v and labels %#v, but did not receive it", c.in, c.labels)
@@ -197,7 +197,12 @@ func TestDecoderSetConcurrency(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			_, err := s.DecodeLabels(in, "concurrency", labels)
+			_, err := s.DecodeLabelsForMetrics(in, "concurrency", labels)
+			if err != nil {
+				t.Error(err)
+			}
+
+			_, err = s.DecodeLabelsForTracing(in, labels)
 			if err != nil {
 				t.Error(err)
 			}
@@ -248,7 +253,7 @@ func TestDecoderSetCache(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	single, err := s.DecodeLabels(in, "one", one)
+	single, err := s.DecodeLabelsForMetrics(in, "one", one)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +262,7 @@ func TestDecoderSetCache(t *testing.T) {
 		t.Errorf("Expected one u64 from %#v, got %#v", one, single)
 	}
 
-	double, err := s.DecodeLabels(in, "two", two)
+	double, err := s.DecodeLabelsForMetrics(in, "two", two)
 	if err != nil {
 		t.Error(err)
 	}
@@ -330,7 +335,7 @@ func BenchmarkCache(b *testing.B) {
 
 	b.Run("cached", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, err := s.DecodeLabels(in, "test", labels)
+			_, err := s.DecodeLabelsForMetrics(in, "test", labels)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -518,7 +518,7 @@ func (e *Exporter) mapValues(module *libbpfgo.Module, name string, labels []conf
 			raw = raw[4:]
 		}
 
-		metricValues[i].labels, err = e.decoders.DecodeLabels(raw, name, labels)
+		metricValues[i].labels, err = e.decoders.DecodeLabelsForMetrics(raw, name, labels)
 		if err != nil {
 			if err == decoder.ErrSkipLabelSet {
 				continue

--- a/exporter/perf_event_array.go
+++ b/exporter/perf_event_array.go
@@ -43,7 +43,7 @@ func newPerfEventArraySink(decoders *decoder.Set, module *libbpfgo.Module, count
 				validDataSize += labelConfig.Size
 			}
 
-			labelValues, err := decoders.DecodeLabels(rawBytes[:validDataSize], counterConfig.Name, sink.counterConfig.Labels)
+			labelValues, err := decoders.DecodeLabelsForMetrics(rawBytes[:validDataSize], counterConfig.Name, sink.counterConfig.Labels)
 			if err != nil {
 				if err == decoder.ErrSkipLabelSet {
 					continue

--- a/tracing/extract.go
+++ b/tracing/extract.go
@@ -20,7 +20,7 @@ func extractLabels(raw []byte, decoders *decoder.Set, config config.Span) ([]str
 		validDataSize += labelConfig.Size
 	}
 
-	decoded, err := decoders.DecodeLabels(raw[:validDataSize], config.Name, config.Labels)
+	decoded, err := decoders.DecodeLabelsForTracing(raw[:validDataSize], config.Labels)
 	if err != nil {
 		if err != decoder.ErrSkipLabelSet {
 			return nil, fmt.Errorf("failed to decode labels: %v", err)


### PR DESCRIPTION
In tracing there is no concern with cardinality and one can have PID as a label. With caching enabled, this means that we grow the cache map indefinitely, leaking memory until OOM stops us. Let's disable caching for tracing instead.