### PR TITLE
Add ext4dist example

### DIFF
--- a/examples/ext4dist.bpf.c
+++ b/examples/ext4dist.bpf.c
@@ -1,0 +1,125 @@
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include "maps.bpf.h"
+
+#define MAX_ENTRIES 10240
+
+// 27 buckets for latency, max range is 33.6s .. 67.1s
+#define MAX_LATENCY_SLOT 27
+
+struct ext4_latency_key_t {
+    u8 op;
+    u64 bucket;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, MAX_ENTRIES);
+    __type(key, u32);
+    __type(value, u64);
+} start SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, MAX_LATENCY_SLOT + 1);
+    __type(key, struct ext4_latency_key_t);
+    __type(value, u64);
+} ext4_latency_seconds SEC(".maps");
+
+enum fs_file_op {
+    F_READ,
+    F_WRITE,
+    F_OPEN,
+    F_FSYNC,
+    F_GETATTR,
+};
+static int probe_entry()
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    u64 ts = bpf_ktime_get_ns();
+
+    bpf_map_update_elem(&start, &pid, &ts, BPF_ANY);
+
+    return 0;
+}
+
+static int probe_return(enum fs_file_op op)
+{
+    u64 *tsp, delta_us, ts = bpf_ktime_get_ns();
+    u32 pid = bpf_get_current_pid_tgid();
+    struct ext4_latency_key_t key = {};
+
+    tsp = bpf_map_lookup_elem(&start, &pid);
+    if (!tsp) {
+        return 0;
+    }
+    delta_us = (ts - *tsp) / 1000;
+    key.op = op;
+
+    increment_exp2_histogram(&ext4_latency_seconds, key, delta_us, MAX_LATENCY_SLOT);
+
+    bpf_map_delete_elem(&start, &pid);
+    return 0;
+}
+
+SEC("kprobe/ext4_file_read_iter")
+int ext4_file_read_enter()
+{
+    return probe_entry();
+}
+
+SEC("kretprobe/ext4_file_read_iter")
+int ext4_file_read_exit()
+{
+    return probe_return(F_READ);
+}
+
+SEC("kprobe/ext4_file_write_iter")
+int ext4_file_write_enter()
+{
+    return probe_entry();
+}
+
+SEC("kretprobe/ext4_file_write_iter")
+int ext4_file_write_exit()
+{
+    return probe_return(F_WRITE);
+}
+
+SEC("kprobe/ext4_file_open")
+int ext4_file_open_enter()
+{
+    return probe_entry();
+}
+
+SEC("kretprobe/ext4_file_open")
+int ext4_file_open_exit()
+{
+    return probe_return(F_OPEN);
+}
+
+SEC("kprobe/ext4_sync_file")
+int ext4_file_sync_enter()
+{
+    return probe_entry();
+}
+
+SEC("kretprobe/ext4_sync_file")
+int ext4_file_sync_exit()
+{
+    return probe_return(F_FSYNC);
+}
+
+SEC("kprobe/ext4_file_getattr")
+int ext4_file_getattr_enter()
+{
+    return probe_entry();
+}
+
+SEC("kretprobe/ext4_file_getattr")
+int ext4_file_getattr_exit()
+{
+    return probe_return(F_GETATTR);
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/examples/ext4dist.yaml
+++ b/examples/ext4dist.yaml
@@ -8,7 +8,7 @@ metrics:
       bucket_multiplier: 0.000001 # microseconds to seconds
       labels:
         - name: operation
-          size: 8
+          size: 1
           decoders:
             - name: uint
             - name: static_map
@@ -19,6 +19,6 @@ metrics:
                 3: sync
                 4: getattr
         - name: bucket
-          size: 8
+          size: 1
           decoders:
             - name: uint

--- a/examples/ext4dist.yaml
+++ b/examples/ext4dist.yaml
@@ -1,0 +1,24 @@
+metrics:
+  histograms:
+    - name: ext4_latency_seconds
+      help: ext4 IO latency histogram
+      bucket_type: exp2
+      bucket_min: 0
+      bucket_max: 27
+      bucket_multiplier: 0.000001 # microseconds to seconds
+      labels:
+        - name: operation
+          size: 8
+          decoders:
+            - name: uint
+            - name: static_map
+              static_map:
+                0: read
+                1: write
+                2: open
+                3: sync
+                4: getattr
+        - name: bucket
+          size: 8
+          decoders:
+            - name: uint


### PR DESCRIPTION
```
curl -s localhost:9435/metrics | grep ext4
ebpf_exporter_ebpf_program_info{config="ext4dist",id="550",program="ext4_file_read_enter",tag="a2782e80c654b953"} 1
ebpf_exporter_ebpf_program_info{config="ext4dist",id="551",program="ext4_file_read_exit",tag="b1acc87832439f22"} 1
ebpf_exporter_ebpf_program_info{config="ext4dist",id="552",program="ext4_file_write_enter",tag="a2782e80c654b953"} 1
ebpf_exporter_ebpf_program_info{config="ext4dist",id="553",program="ext4_file_write_exit",tag="43604b1f9f9af187"} 1
ebpf_exporter_ebpf_program_info{config="ext4dist",id="554",program="ext4_file_open_enter",tag="a2782e80c654b953"} 1
ebpf_exporter_ebpf_program_info{config="ext4dist",id="555",program="ext4_file_open_exit",tag="26f0c2a9c21f4b5a"} 1
ebpf_exporter_ebpf_program_info{config="ext4dist",id="556",program="ext4_file_sync_enter",tag="a2782e80c654b953"} 1
ebpf_exporter_ebpf_program_info{config="ext4dist",id="557",program="ext4_file_sync_exit",tag="818b98d1be4edcaf"} 1
ebpf_exporter_ebpf_program_info{config="ext4dist",id="558",program="ext4_file_getattr_enter",tag="a2782e80c654b953"} 1
ebpf_exporter_ebpf_program_info{config="ext4dist",id="559",program="ext4_file_getattr_exit",tag="1f4ac0b8c11d7741"} 1
ebpf_exporter_enabled_configs{name="ext4dist"} 1
# HELP ebpf_exporter_ext4_latency_seconds ext4 IO latency histogram
# TYPE ebpf_exporter_ext4_latency_seconds histogram
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="1e-06"} 37834
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="2e-06"} 38791
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="4e-06"} 39104
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="8e-06"} 39122
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="1.6e-05"} 39128
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="3.2e-05"} 39128
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="6.4e-05"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="0.000128"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="0.000256"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="0.000512"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="0.001024"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="0.002048"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="0.004096"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="0.008192"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="0.016384"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="0.032768"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="0.065536"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="0.131072"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="0.262144"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="0.524288"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="1.048576"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="2.097152"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="4.194304"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="8.388608"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="16.777216"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="33.554432"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="67.108864"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="134.217728"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="getattr",le="+Inf"} 39135
ebpf_exporter_ext4_latency_seconds_sum{operation="getattr"} 0.007614999999999999
ebpf_exporter_ext4_latency_seconds_count{operation="getattr"} 39135
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="1e-06"} 19728
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="2e-06"} 20353
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="4e-06"} 21185
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="8e-06"} 21185
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="1.6e-05"} 21185
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="3.2e-05"} 21185
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="6.4e-05"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="0.000128"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="0.000256"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="0.000512"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="0.001024"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="0.002048"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="0.004096"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="0.008192"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="0.016384"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="0.032768"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="0.065536"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="0.131072"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="0.262144"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="0.524288"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="1.048576"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="2.097152"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="4.194304"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="8.388608"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="16.777216"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="33.554432"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="67.108864"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="134.217728"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="open",le="+Inf"} 21187
ebpf_exporter_ext4_latency_seconds_sum{operation="open"} 0.008079
ebpf_exporter_ext4_latency_seconds_count{operation="open"} 21187
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="1e-06"} 23852
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="2e-06"} 30439
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="4e-06"} 37771
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="8e-06"} 38798
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="1.6e-05"} 39283
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="3.2e-05"} 39370
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="6.4e-05"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="0.000128"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="0.000256"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="0.000512"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="0.001024"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="0.002048"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="0.004096"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="0.008192"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="0.016384"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="0.032768"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="0.065536"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="0.131072"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="0.262144"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="0.524288"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="1.048576"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="2.097152"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="4.194304"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="8.388608"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="16.777216"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="33.554432"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="67.108864"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="134.217728"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="read",le="+Inf"} 39398
ebpf_exporter_ext4_latency_seconds_sum{operation="read"} 0.148206
ebpf_exporter_ext4_latency_seconds_count{operation="read"} 39398
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="1e-06"} 185
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="2e-06"} 650
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="4e-06"} 1342
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="8e-06"} 1906
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="1.6e-05"} 2651
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="3.2e-05"} 2977
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="6.4e-05"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="0.000128"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="0.000256"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="0.000512"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="0.001024"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="0.002048"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="0.004096"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="0.008192"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="0.016384"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="0.032768"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="0.065536"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="0.131072"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="0.262144"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="0.524288"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="1.048576"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="2.097152"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="4.194304"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="8.388608"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="16.777216"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="33.554432"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="67.108864"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="134.217728"} 3006
ebpf_exporter_ext4_latency_seconds_bucket{operation="write",le="+Inf"} 3006
ebpf_exporter_ext4_latency_seconds_sum{operation="write"} 0.071592
ebpf_exporter_ext4_latency_seconds_count{operation="write"} 3006
```