### PR TITLE
Add xfsdist example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,6 +447,10 @@ jobs:
       - name: Extract tracing-demos.x86_64.tar.gz
         run: tar -xzvf tracing-demos.x86_64.tar.gz
 
+      # Some programs expect to attach to symbols in modules
+      - name: Load expected kernel modules
+        run: sudo modprobe xfs
+
       - name: Run configuration check
         run: make config-check
 

--- a/examples/xfsdist.bpf.c
+++ b/examples/xfsdist.bpf.c
@@ -1,0 +1,114 @@
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include "maps.bpf.h"
+
+#define MAX_ENTRIES 10240
+
+// 27 buckets for latency, max range is 33.6s .. 67.1s
+#define MAX_LATENCY_SLOT 27
+
+enum fs_file_op {
+    F_READ,
+    F_WRITE,
+    F_OPEN,
+    F_FSYNC,
+};
+
+struct xfs_latency_key_t {
+    u8 op;
+    u8 bucket;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(max_entries, MAX_ENTRIES);
+    __type(key, u32);
+    __type(value, u64);
+} start SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, MAX_LATENCY_SLOT + 1);
+    __type(key, struct xfs_latency_key_t);
+    __type(value, u64);
+} xfs_latency_seconds SEC(".maps");
+
+static int probe_entry()
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    u64 ts = bpf_ktime_get_ns();
+
+    bpf_map_update_elem(&start, &pid, &ts, BPF_ANY);
+
+    return 0;
+}
+
+static int probe_return(enum fs_file_op op)
+{
+    u64 *tsp, delta_us, ts = bpf_ktime_get_ns();
+    u32 pid = bpf_get_current_pid_tgid();
+    struct xfs_latency_key_t key = { .op = (u8) op };
+
+    tsp = bpf_map_lookup_elem(&start, &pid);
+    if (!tsp) {
+        return 0;
+    }
+
+    delta_us = (ts - *tsp) / 1000;
+
+    increment_exp2_histogram(&xfs_latency_seconds, key, delta_us, MAX_LATENCY_SLOT);
+
+    bpf_map_delete_elem(&start, &pid);
+
+    return 0;
+}
+
+SEC("kprobe/xfs_file_read_iter")
+int xfs_file_read_enter()
+{
+    return probe_entry();
+}
+
+SEC("kretprobe/xfs_file_read_iter")
+int xfs_file_read_exit()
+{
+    return probe_return(F_READ);
+}
+
+SEC("kprobe/xfs_file_write_iter")
+int xfs_file_write_enter()
+{
+    return probe_entry();
+}
+
+SEC("kretprobe/xfs_file_write_iter")
+int xfs_file_write_exit()
+{
+    return probe_return(F_WRITE);
+}
+
+SEC("kprobe/xfs_file_open")
+int xfs_file_open_enter()
+{
+    return probe_entry();
+}
+
+SEC("kretprobe/xfs_file_open")
+int xfs_file_open_exit()
+{
+    return probe_return(F_OPEN);
+}
+
+SEC("kprobe/xfs_file_fsync")
+int xfs_file_sync_enter()
+{
+    return probe_entry();
+}
+
+SEC("kretprobe/xfs_file_fsync")
+int xfs_file_sync_exit()
+{
+    return probe_return(F_FSYNC);
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/examples/xfsdist.yaml
+++ b/examples/xfsdist.yaml
@@ -1,0 +1,23 @@
+metrics:
+  histograms:
+    - name: xfs_latency_seconds
+      help: xfs IO latency histogram
+      bucket_type: exp2
+      bucket_min: 0
+      bucket_max: 27
+      bucket_multiplier: 0.000001 # microseconds to seconds
+      labels:
+        - name: operation
+          size: 1
+          decoders:
+            - name: uint
+            - name: static_map
+              static_map:
+                0: read
+                1: write
+                2: open
+                3: sync
+        - name: bucket
+          size: 1
+          decoders:
+            - name: uint


### PR DESCRIPTION
A similar PR to [ext4dist](https://github.com/cloudflare/ebpf_exporter/pull/365) for XFS

```
$ curl -s localhost:9435/metrics | grep xfs
ebpf_exporter_ebpf_program_info{config="xfsdist",id="2151",program="xfs_file_read_enter",tag="a2782e80c654b953"} 1
ebpf_exporter_ebpf_program_info{config="xfsdist",id="2152",program="xfs_file_read_exit",tag="38615d37ed968a64"} 1
ebpf_exporter_ebpf_program_info{config="xfsdist",id="2153",program="xfs_file_write_enter",tag="a2782e80c654b953"} 1
ebpf_exporter_ebpf_program_info{config="xfsdist",id="2154",program="xfs_file_write_exit",tag="89fc999dbdd00924"} 1
ebpf_exporter_ebpf_program_info{config="xfsdist",id="2155",program="xfs_file_open_enter",tag="a2782e80c654b953"} 1
ebpf_exporter_ebpf_program_info{config="xfsdist",id="2156",program="xfs_file_open_exit",tag="f0481afbbba7aad1"} 1
ebpf_exporter_ebpf_program_info{config="xfsdist",id="2157",program="xfs_file_sync_enter",tag="a2782e80c654b953"} 1
ebpf_exporter_ebpf_program_info{config="xfsdist",id="2158",program="xfs_file_sync_exit",tag="785ee7064f87a9f1"} 1
# HELP ebpf_exporter_enabled_configs The set of enabled configs
# TYPE ebpf_exporter_enabled_configs gauge
ebpf_exporter_enabled_configs{name="xfsdist"} 1
# HELP ebpf_exporter_xfs_latency_seconds xfs IO latency histogram
# TYPE ebpf_exporter_xfs_latency_seconds histogram
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="1e-06"} 1117
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="2e-06"} 1168
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="4e-06"} 1242
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="8e-06"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="1.6e-05"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="3.2e-05"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="6.4e-05"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="0.000128"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="0.000256"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="0.000512"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="0.001024"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="0.002048"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="0.004096"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="0.008192"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="0.016384"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="0.032768"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="0.065536"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="0.131072"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="0.262144"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="0.524288"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="1.048576"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="2.097152"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="4.194304"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="8.388608"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="16.777216"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="33.554432"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="67.108864"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="134.217728"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="open",le="+Inf"} 1245
ebpf_exporter_xfs_latency_seconds_sum{operation="open"} 0.0005899999999999999
ebpf_exporter_xfs_latency_seconds_count{operation="open"} 1245
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="1e-06"} 976
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="2e-06"} 1090
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="4e-06"} 1151
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="8e-06"} 1177
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="1.6e-05"} 1198
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="3.2e-05"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="6.4e-05"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="0.000128"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="0.000256"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="0.000512"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="0.001024"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="0.002048"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="0.004096"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="0.008192"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="0.016384"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="0.032768"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="0.065536"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="0.131072"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="0.262144"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="0.524288"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="1.048576"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="2.097152"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="4.194304"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="8.388608"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="16.777216"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="33.554432"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="67.108864"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="134.217728"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="read",le="+Inf"} 1201
ebpf_exporter_xfs_latency_seconds_sum{operation="read"} 0.001838
ebpf_exporter_xfs_latency_seconds_count{operation="read"} 1201
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="1e-06"} 0
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="2e-06"} 0
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="4e-06"} 0
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="8e-06"} 0
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="1.6e-05"} 0
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="3.2e-05"} 17
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="6.4e-05"} 26
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="0.000128"} 28
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="0.000256"} 28
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="0.000512"} 28
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="0.001024"} 28
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="0.002048"} 45
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="0.004096"} 54
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="0.008192"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="0.016384"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="0.032768"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="0.065536"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="0.131072"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="0.262144"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="0.524288"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="1.048576"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="2.097152"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="4.194304"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="8.388608"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="16.777216"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="33.554432"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="67.108864"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="134.217728"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="sync",le="+Inf"} 56
ebpf_exporter_xfs_latency_seconds_sum{operation="sync"} 0.130712
ebpf_exporter_xfs_latency_seconds_count{operation="sync"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="1e-06"} 0
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="2e-06"} 14
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="4e-06"} 21
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="8e-06"} 30
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="1.6e-05"} 49
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="3.2e-05"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="6.4e-05"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="0.000128"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="0.000256"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="0.000512"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="0.001024"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="0.002048"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="0.004096"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="0.008192"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="0.016384"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="0.032768"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="0.065536"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="0.131072"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="0.262144"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="0.524288"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="1.048576"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="2.097152"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="4.194304"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="8.388608"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="16.777216"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="33.554432"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="67.108864"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="134.217728"} 56
ebpf_exporter_xfs_latency_seconds_bucket{operation="write",le="+Inf"} 56
ebpf_exporter_xfs_latency_seconds_sum{operation="write"} 0.000878
ebpf_exporter_xfs_latency_seconds_count{operation="write"} 56
```