### PR TITLE
Correctly size latency BPF hash maps in multi-operation latency programs

### DIFF
--- a/examples/biolatency.bpf.c
+++ b/examples/biolatency.bpf.c
@@ -6,6 +6,10 @@
 // Max number of disks we expect to see on the host
 #define MAX_DISKS 255
 
+// Max number of different request ops we expect to see in use.
+// As of 6.9-rc2, Linux defines 14 REQ_OP_* in include/linux/blk_types.h
+#define MAX_REQ_OPS 14
+
 // 27 buckets for latency, max range is 33.6s .. 67.1s
 #define MAX_LATENCY_SLOT 27
 
@@ -31,7 +35,7 @@ struct {
 
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
-    __uint(max_entries, (MAX_LATENCY_SLOT + 1) * MAX_DISKS);
+    __uint(max_entries, (MAX_LATENCY_SLOT + 1) * MAX_DISKS * MAX_REQ_OPS);
     __type(key, struct disk_latency_key_t);
     __type(value, u64);
 } bio_latency_seconds SEC(".maps");

--- a/examples/ext4dist.bpf.c
+++ b/examples/ext4dist.bpf.c
@@ -13,6 +13,8 @@ enum fs_file_op {
     F_OPEN,
     F_FSYNC,
     F_GETATTR,
+
+    F_MAX
 };
 
 struct ext4_latency_key_t {
@@ -29,7 +31,7 @@ struct {
 
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
-    __uint(max_entries, MAX_LATENCY_SLOT + 1);
+    __uint(max_entries, (MAX_LATENCY_SLOT + 1) * F_MAX);
     __type(key, struct ext4_latency_key_t);
     __type(value, u64);
 } ext4_latency_seconds SEC(".maps");

--- a/examples/xfsdist.bpf.c
+++ b/examples/xfsdist.bpf.c
@@ -12,6 +12,8 @@ enum fs_file_op {
     F_WRITE,
     F_OPEN,
     F_FSYNC,
+
+    F_MAX
 };
 
 struct xfs_latency_key_t {
@@ -28,7 +30,7 @@ struct {
 
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
-    __uint(max_entries, MAX_LATENCY_SLOT + 1);
+    __uint(max_entries, (MAX_LATENCY_SLOT + 1) * F_MAX);
     __type(key, struct xfs_latency_key_t);
     __type(value, u64);
 } xfs_latency_seconds SEC(".maps");


### PR DESCRIPTION
Several BPF examples (ext4dist, xfsdist, and biolatency) accumulate latency histograms for multiple operations but size their BPF hash maps used for the latency histogram buckets as if they were only accumulating a single operation, reported as issue #371. These two commits update all three examples to correctly size their BPF hash maps. For ext4dist and xfsdist this is simple because the number of operations is set by the example's code. For biolatency the different operations come from the kernel, so we opt to be relatively conservative and size by the number of currently known operations as of 6.9-rc2. We could use the larger ``REQ_OP_LAST`` from include/linux/blk_types.h if desired; this last changed in 2022.

In ext4dist and xfsdist, the new ``F_MAX`` constant is deliberately set off from the other constants and does not have a comma after it since nothing should be added after it.

I could not find any other examples that seemed to have this pattern of under-sized BPF hash maps for latency, so I believe this will fully resolve the issues discovered in #371.