### PR TITLE
examples/biolatency: correct the name of operation 35

### DIFF
--- a/examples/biolatency.yaml
+++ b/examples/biolatency.yaml
@@ -27,7 +27,7 @@ metrics:
                 5: secure_erase
                 9: write_zeroes
                 34: drv_in
-                35: drv_in
+                35: drv_out
         - name: bucket
           size: 8
           decoders:


### PR DESCRIPTION
Bio request operation 35 is REQ_OP_DRV_OUT, and should be called 'drv_out' in the label. Unfortunately when I added it in a previous commit I duplicated the name of the previous entry so it was mis-labeled as 'drv_in'. This is especially bad as it could lead to label duplications in visible Prometheus metrics.