### PR TITLE
Add padding label config key

### DIFF
--- a/.vscode/config-schema.yaml
+++ b/.vscode/config-schema.yaml
@@ -111,6 +111,8 @@ definitions:
           type: string
         size:
           type: number
+        padding:
+          type: number
         decoders:
           type: array
           items:

--- a/README.md
+++ b/README.md
@@ -555,7 +555,8 @@ Is represented as:
 * 3 byte padding to align `slot`
 * 8 byte `slot` integer
 
-When decoding, label sizes should be supplied with padding included:
+When decoding, either specify the padding explicitly with the key `padding` or
+include it in the label size:
 
 * 4 for `dev`
 * 4 for `op` (1 byte value + 3 byte padding)
@@ -777,7 +778,8 @@ See [Labels](#labels) section for more details.
 
 ```
 name: <prometheus label name>
-size: <field size with padding>
+size: <field size>
+padding: <padding size>
 decoders:
   [ - decoder ]
 ```

--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,7 @@ type Span struct {
 type Label struct {
 	Name     string    `yaml:"name"`
 	Size     uint      `yaml:"size"`
+	Padding  uint      `yaml:"padding"`
 	Decoders []Decoder `yaml:"decoders"`
 }
 

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -137,7 +137,7 @@ func (s *Set) decodeLabels(in []byte, labels []config.Label) ([]string, error) {
 			return nil, fmt.Errorf("error decoding label %q: size is zero or not set", label.Name)
 		}
 
-		totalSize += size
+		totalSize += size + label.Padding
 	}
 
 	if totalSize != uint(len(in)) {
@@ -156,7 +156,7 @@ func (s *Set) decodeLabels(in []byte, labels []config.Label) ([]string, error) {
 			return nil, err
 		}
 
-		off += size
+		off += size + label.Padding
 
 		values[i] = string(decoded)
 	}

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -57,6 +57,32 @@ func TestDecodeLabels(t *testing.T) {
 			err: false,
 		},
 		{
+			in: append([]byte{0x8, 0x1, 0x1, 0x1}, zeroPaddedString("bananas", 32)...),
+			labels: []config.Label{
+				{
+					Name:    "number",
+					Size:    1,
+					Padding: 3, // only first byte should be used  for the label
+					Decoders: []config.Decoder{
+						{
+							Name: "uint",
+						},
+					},
+				},
+				{
+					Name: "fruit",
+					Size: 32,
+					Decoders: []config.Decoder{
+						{
+							Name: "string",
+						},
+					},
+				},
+			},
+			out: []string{"8", "bananas"},
+			err: false,
+		},
+		{
 			in: append([]byte{0x8, 0x0, 0x0, 0x0}, zeroPaddedString("bananas", 32)...),
 			labels: []config.Label{
 				{

--- a/examples/inet-frags.yaml
+++ b/examples/inet-frags.yaml
@@ -8,6 +8,7 @@ metrics:
           decoders:
             - name: ifname
         - name: ip_version
-          size: 4
+          size: 1
+          padding: 3
           decoders:
             - name: uint

--- a/exporter/perf_event_array.go
+++ b/exporter/perf_event_array.go
@@ -40,7 +40,7 @@ func newPerfEventArraySink(decoders *decoder.Set, module *libbpfgo.Module, count
 			// https://lore.kernel.org/patchwork/patch/1244339/
 			var validDataSize uint
 			for _, labelConfig := range sink.counterConfig.Labels {
-				validDataSize += labelConfig.Size
+				validDataSize += labelConfig.Size + labelConfig.Padding
 			}
 
 			labelValues, err := decoders.DecodeLabelsForMetrics(rawBytes[:validDataSize], counterConfig.Name, sink.counterConfig.Labels)

--- a/tracing/extract.go
+++ b/tracing/extract.go
@@ -17,7 +17,7 @@ var nilSpanID = "0000000000000000"
 func extractLabels(raw []byte, decoders *decoder.Set, config config.Span) ([]string, error) {
 	var validDataSize uint
 	for _, labelConfig := range config.Labels {
-		validDataSize += labelConfig.Size
+		validDataSize += labelConfig.Size + labelConfig.Padding
 	}
 
 	decoded, err := decoders.DecodeLabelsForTracing(raw[:validDataSize], config.Labels)


### PR DESCRIPTION
Padding bytes in the map key struct need to be considered in the config of the label. This is done by choosing a larger size for the label's value. For most cases this works fine.

This commit adds a new config key for labels that allows to specify padding bytes explicitly so they can be skipped by decoders.

Closes #369