### PR TITLE
Enable truly static linkage with no nss

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,9 @@ jobs:
       - name: Check static linkage
         run: (ldd --verbose ./ebpf_exporter 2>&1 || true) | grep 'not a dynamic executable'
 
+      - name: Check for nss presence
+        run: if [[ $(objdump -tT ebpf_exporter | grep 'hidden _nss') ]]; then echo "unexpected nss symbols found"; exit 1; fi
+
       - name: Check that it runs
         run: ./ebpf_exporter --version
 
@@ -200,6 +203,9 @@ jobs:
 
       - name: Check static linkage
         run: (ldd --verbose ./ebpf_exporter 2>&1 || true) | grep 'not a dynamic executable'
+
+      - name: Check for nss presence
+        run: if [[ $(objdump -tT ebpf_exporter | grep 'hidden _nss') ]]; then echo "unexpected nss symbols found"; exit 1; fi
 
       - name: Check that it runs
         run: ./ebpf_exporter --version

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ build: build-static
 
 .PHONY: build-static
 build-static:
-	$(MAKE) build-binary GO_LDFLAGS='-extldflags "-static"'
+	$(MAKE) build-binary GO_BUILD_ARGS="-tags netgo,osusergo" GO_LDFLAGS='-extldflags "-static"'
 
 .PHONY: build-dynamic
 build-dynamic:
@@ -78,7 +78,7 @@ build-dynamic:
 
 .PHONY: build-binary
 build-binary: $(LIBBPF_DEPS)
-	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" go build -o ebpf_exporter -v -ldflags="$(GO_LDFLAGS) $(GO_LDFLAGS_VARS)" ./cmd/ebpf_exporter
+	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" go build $(GO_BUILD_ARGS) -o ebpf_exporter -v -ldflags="$(GO_LDFLAGS) $(GO_LDFLAGS_VARS)" ./cmd/ebpf_exporter
 
 .PHONY: examples
 examples:


### PR DESCRIPTION
Suppressing these:

```
/usr/bin/ld: /tmp/go-link-386518740/000055.o: in function `mygetgrouplist':
getgrouplist_unix.cgo2.c:(.text+0x50): warning: Using 'getgrouplist' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-386518740/000054.o: in function `mygetgrgid_r':
cgo_lookup_cgo.cgo2.c:(.text+0x1b0): warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-386518740/000054.o: in function `mygetgrnam_r':
cgo_lookup_cgo.cgo2.c:(.text+0x248): warning: Using 'getgrnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-386518740/000054.o: in function `mygetpwnam_r':
cgo_lookup_cgo.cgo2.c:(.text+0x114): warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-386518740/000054.o: in function `mygetpwuid_r':
cgo_lookup_cgo.cgo2.c:(.text+0x74): warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-386518740/000004.o: in function `_cgo_9c8efe9babca_C2func_getaddrinfo':
cgo_unix_cgo.cgo2.c:(.text+0x74): warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
make[1]: Leaving directory '/mnt/data/homes/ivan/projects/ebpf_exporter'
```