### PR TITLE
Use dynamic linking for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ clang-format-check:
 
 .PHONY: test
 test: $(LIBBPF_DEPS)
-	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" go test -ldflags='-extldflags "-static"' $(GO_TEST_ARGS) ./...
+	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" go test $(GO_TEST_ARGS) ./...
 
 .PHONY: test-privileged
 test-privileged:

--- a/Makefile.libbpf
+++ b/Makefile.libbpf
@@ -10,6 +10,8 @@ LIBBPF_CFLAGS := -I$(LIBBPF_TOP)/libbpf/dest/usr/include
 LIBBPF_LDFLAGS := -L$(LIBBPF_TOP)/libbpf/dest/usr/lib
 CGO_LDFLAGS := $(CGO_LDFLAGS) $(LIBBPF_LDFLAGS)
 CGO_CFLAGS := $(LIBBPF_CFLAGS)
+
+export LD_LIBRARY_PATH=$(LIBBPF_TOP)/libbpf/dest/usr/lib
 endif
 
 .PHONY: clean-libbpf

--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -18,4 +18,4 @@ run: build $(LIBBPF_DEPS)
 	# * https://github.com/golang/go/blob/go1.21.0/src/cmd/go/internal/test/test.go#L1028
 	# * https://github.com/golang/go/blob/go1.21.0/src/cmd/go/internal/test/test.go#L630-L631
 	# The symbols are necessary to attach a uprobe to itself.
-	sudo GOMAXPROCS=1 CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go test -ldflags='-extldflags "-static"' -o benchmark.test -bench .
+	sudo LD_LIBRARY_PATH=$(LD_LIBRARY_PATH) GOMAXPROCS=1 CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go test -o benchmark.test -bench .


### PR DESCRIPTION
Tests run a bit faster when static linking is not enabled.