### PR TITLE
Group opentelemetry dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
       - dependency-type: all
     schedule:
       interval: monthly
+    groups:
+      opentelemetry:
+        applies-to: version-updates
+        patterns:
+          - go.opentelemetry.io/*


### PR DESCRIPTION
Without this dependabot opens a bunch of PRs for individual packages that all bump to the same version and ofter conflict with each other.