### PR TITLE
Add ebpf_exporter.config tag to tracing spans

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -399,7 +399,7 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 			log.Printf("Tracing is not enabled, but some spans are configured in config %q", cfg.Name)
 		} else {
 			for _, span := range cfg.Tracing.Spans {
-				startTracingSink(e.tracingProvider, e.decoders, e.modules[cfg.Name], span, e.decoderErrorCount.WithLabelValues(cfg.Name))
+				startTracingSink(e.tracingProvider, e.decoders, e.modules[cfg.Name], cfg.Name, span, e.decoderErrorCount.WithLabelValues(cfg.Name))
 			}
 		}
 	}

--- a/exporter/ringbuf.go
+++ b/exporter/ringbuf.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func startTracingSink(provider tracing.Provider, decoders *decoder.Set, module *libbpfgo.Module, config config.Span, errors prometheus.Counter) {
+func startTracingSink(provider tracing.Provider, decoders *decoder.Set, module *libbpfgo.Module, configName string, config config.Span, errors prometheus.Counter) {
 	input := make(chan []byte)
 
 	ringBuf, err := module.InitRingBuf(config.RingBuf, input)
@@ -18,7 +18,7 @@ func startTracingSink(provider tracing.Provider, decoders *decoder.Set, module *
 		log.Fatalf("Error initializing ringbuf %q: %v", config.RingBuf, err)
 	}
 
-	go tracing.HandleInput(input, provider, decoders, config, errors)
+	go tracing.HandleInput(input, provider, decoders, configName, config, errors)
 
 	ringBuf.Poll(325)
 }

--- a/tracing/extract.go
+++ b/tracing/extract.go
@@ -105,11 +105,13 @@ func extractSpan(labels []string, config config.Span) (string, time.Time, time.D
 	return name, timestamp, duration, traceID, parentID, spanID, attributes, nil
 }
 
-func handleDecodedLabels(provider Provider, labels []string, config config.Span) error {
+func handleDecodedLabels(provider Provider, labels []string, configName string, config config.Span) error {
 	name, timestamp, duration, traceID, parentID, spanID, attributes, err := extractSpan(labels, config)
 	if err != nil {
 		return err
 	}
+
+	attributes = append(attributes, attribute.String("ebpf_exporter.config", configName))
 
 	tracer := provider.Tracer(config.Service)
 

--- a/tracing/input.go
+++ b/tracing/input.go
@@ -9,9 +9,9 @@ import (
 )
 
 // HandleInput reads inputs from the input channel and turns them into spans
-func HandleInput(input <-chan []byte, provider Provider, decoders *decoder.Set, config config.Span, errors prometheus.Counter) {
+func HandleInput(input <-chan []byte, provider Provider, decoders *decoder.Set, configName string, config config.Span, errors prometheus.Counter) {
 	for raw := range input {
-		err := handleRawBytes(raw, provider, decoders, config)
+		err := handleRawBytes(raw, provider, decoders, configName, config)
 		if err != nil {
 			if err != decoder.ErrSkipLabelSet {
 				errors.Inc()
@@ -23,11 +23,11 @@ func HandleInput(input <-chan []byte, provider Provider, decoders *decoder.Set, 
 	}
 }
 
-func handleRawBytes(raw []byte, provider Provider, decoders *decoder.Set, config config.Span) error {
+func handleRawBytes(raw []byte, provider Provider, decoders *decoder.Set, configName string, config config.Span) error {
 	decoded, err := extractLabels(raw, decoders, config)
 	if err != nil {
 		return err
 	}
 
-	return handleDecodedLabels(provider, decoded, config)
+	return handleDecodedLabels(provider, decoded, configName, config)
 }


### PR DESCRIPTION
Sometimes multiple configs can produce the same span name. It is useful to know which triggered the span, so that search is easier.

<img width="1073" alt="image" src="https://github.com/cloudflare/ebpf_exporter/assets/89186/b552988f-0b66-47bd-a2b5-ec65709b405f">
