### PR TITLE
Skip nil links on detach to avoid panic

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -253,6 +253,10 @@ func (e *Exporter) Detach() {
 		_, moduleCloseSpan := tracer.Start(ctx, "close_module", trace.WithAttributes(attribute.String("config", name)))
 
 		for prog, link := range e.attachedProgs[name] {
+			if link == nil {
+				continue
+			}
+
 			moduleCloseSpan.AddEvent("prog_detach", trace.WithAttributes(attribute.String("SEC", prog.SectionName())))
 
 			if err := link.Destroy(); err != nil {


### PR DESCRIPTION
This can happen if any links were missing on attach:

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x79da68]

goroutine 51 [running]:
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
    /home/ivan/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.27.0/trace/span.go:381 +0x2c
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0x400014ac00, {0x0, 0x0, 0x40001dd880?})
    /home/ivan/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.27.0/trace/span.go:419 +0x8ac
panic({0xc253a0?, 0x13420b0?})
    /opt/go/src/runtime/panic.go:770 +0x124
github.com/aquasecurity/libbpfgo.(*BPFLink).Destroy(0x40000d23f0?)
    /home/ivan/go/pkg/mod/github.com/aquasecurity/libbpfgo@v0.7.0-libbpf-1.4/link.go:68 +0x18
github.com/cloudflare/ebpf_exporter/v2/exporter.(*Exporter).Detach(0x40000ea000)
    /home/ivan/projects/ebpf_exporter/exporter/exporter.go:260 +0x678
main.handleSignals(0x40000ea000, {0xe32418, 0x40001e1540}, 0x0)
    /home/ivan/projects/ebpf_exporter/cmd/ebpf_exporter/main.go:256 +0x150
created by main.main in goroutine 1
    /home/ivan/projects/ebpf_exporter/cmd/ebpf_exporter/main.go:168 +0x1c28
```