### PR TITLE
Learning ebpf_exporter by adding examples/cgroup-rstat-flushing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ CLANG_FORMAT_FILES = ${wildcard examples/*.c examples/*.h benchmark/probes/*.c b
 # * cachestat-pre-kernel-5.16 fails to attach in newer kernels (see code)
 # * llcstat requires real hardware to attach perf events, which is not present in ci
 CONFIGS_TO_IGNORE_IN_CHECK := cachestat-pre-kernel-5.16 llcstat
+# * cgroup-rstat-flushing depend on kernel v6.10, which is not yet on CI system
+CONFIGS_TO_IGNORE_IN_CHECK += cgroup-rstat-flushing
 CONFIGS_TO_CHECK := $(filter-out $(CONFIGS_TO_IGNORE_IN_CHECK), ${patsubst examples/%.yaml, %, ${wildcard examples/*.yaml}})
 
 CGO_LDFLAGS_DYNAMIC = -l bpf

--- a/examples/cgroup-rstat-flushing.bpf.c
+++ b/examples/cgroup-rstat-flushing.bpf.c
@@ -83,8 +83,8 @@ int BPF_PROG(rstat_locked, struct cgroup *cgrp, int cpu, bool contended)
 		(*cnt)++;
 	}
 
-	/* What cgrp level is interesting, but I didn't manage to encode it in
-	 * above counters.  As contended case is the most interesting, have
+	/* What cgroup level is interesting, but I didn't manage to encode it
+	 * in above counters.  As contended case is the most interesting, have
 	 * level counter for contended.
 	 */
 	if (contended) {

--- a/examples/cgroup-rstat-flushing.bpf.c
+++ b/examples/cgroup-rstat-flushing.bpf.c
@@ -10,7 +10,7 @@
 #include <vmlinux.h>
 #include <bpf/bpf_tracing.h>
 #include "maps.bpf.h"
-#include "errno.h"
+#include <linux/errno.h>
 
 #define MAX_CGROUP_LEVELS 5
 

--- a/examples/cgroup-rstat-flushing.bpf.c
+++ b/examples/cgroup-rstat-flushing.bpf.c
@@ -30,7 +30,7 @@ struct {
 	__uint(max_entries, 2); /* contended state used as key */
 	__type(key, u32);
 	__type(value, u64);
-} cgroup_rstat_locked_state SEC(".maps");
+} cgroup_rstat_locked_total SEC(".maps");
 
 /* Counter for obtaining lock again after yield (and contended state).
  *
@@ -75,7 +75,7 @@ int BPF_PROG(rstat_locked, struct cgroup *cgrp, int cpu, bool contended)
 	u32 key = contended;
 	u64 *cnt;
 
-	read_array_ptr(&cgroup_rstat_locked_state, &key, cnt);
+	read_array_ptr(&cgroup_rstat_locked_total, &key, cnt);
 	(*cnt)++;
 
 	if (cpu >= 0) {

--- a/examples/cgroup-rstat-flushing.bpf.c
+++ b/examples/cgroup-rstat-flushing.bpf.c
@@ -35,7 +35,7 @@ struct hist_key_t {
 
 struct {
     __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-    __uint(max_entries, MAX_LATENCY_SLOT + 1);
+    __uint(max_entries, MAX_LATENCY_SLOT + 2);
     __type(key, struct hist_key_t);
     __type(value, u64);
 } cgroup_rstat_lock_wait_seconds SEC(".maps");
@@ -49,7 +49,7 @@ struct {
 
 struct {
     __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-    __uint(max_entries, MAX_LATENCY_SLOT + 1);
+    __uint(max_entries, MAX_LATENCY_SLOT + 2);
     __type(key, struct hist_key_t);
     __type(value, u64);
 } cgroup_rstat_lock_hold_seconds SEC(".maps");
@@ -63,7 +63,7 @@ struct {
 
 struct {
     __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-    __uint(max_entries, MAX_LATENCY_SLOT + 1);
+    __uint(max_entries, MAX_LATENCY_SLOT + 2);
     __type(key, struct hist_key_t);
     __type(value, u64);
 } cgroup_rstat_flush_latency_seconds SEC(".maps");
@@ -281,8 +281,6 @@ int BPF_PROG(cgroup_rstat_flush_locked_exit, struct cgroup *cgrp)
      * ebpf_exporter will also have:
      *  ebpf_exporter_cgroup_rstat_flush_latency_seconds_sum and
      *  ebpf_exporter_cgroup_rstat_flush_latency_seconds_count
-     *
-     * Unfortunately _sum isn't getting updated.
      *
      * The Prometheus idea behind having _seconds_count and _seconds_sum
      * =================================================================

--- a/examples/cgroup-rstat-flushing.bpf.c
+++ b/examples/cgroup-rstat-flushing.bpf.c
@@ -80,10 +80,9 @@ struct {
     __type(value, u64);
 } start_flush SEC(".maps");
 
-
 struct flush_key_t {
-	u64 cgrp_id;
-	u32 level;
+    u64 cgrp_id;
+    u32 level;
 } __attribute__((packed));
 
 struct {
@@ -172,7 +171,7 @@ int BPF_PROG(rstat_locked, struct cgroup *cgrp, int cpu, bool contended)
 
         read_array_ptr(&start_wait, &pid, start_wait_ts);
         // TODO: validate LRU lookup success
-	/* Lock wait time */
+        /* Lock wait time */
         delta = (now - *start_wait_ts) / 100; /* 0.1 usec */
 
         increment_exp2_histogram_nosync(&cgroup_rstat_lock_wait_seconds, key, delta, MAX_LATENCY_SLOT);

--- a/examples/cgroup-rstat-flushing.bpf.c
+++ b/examples/cgroup-rstat-flushing.bpf.c
@@ -124,14 +124,14 @@ int BPF_PROG(rstat_locked, struct cgroup *cgrp, int cpu, bool contended)
 	if (contended) {
 		u64 *start_wait_ts;
 		struct hist_key_t key;
-		u64 delta_usec;
+		u64 delta;
 
 		read_array_ptr(&start_wait, &pid, start_wait_ts);
 		// TODO: validate LRU lookup success
-		delta_usec = (now - *start_wait_ts) / 100; /* 0.1 usec */
+		delta = (now - *start_wait_ts) / 100; /* 0.1 usec */
 
 		increment_exp2_histogram_nosync(&cgroup_rstat_lock_wait_seconds,
-						key, delta_usec, MAX_LATENCY_SLOT);
+						key, delta, MAX_LATENCY_SLOT);
 		// Should we reset timestamp?
 		*start_wait_ts = 0;
 	}
@@ -146,14 +146,14 @@ int BPF_PROG(rstat_unlock, struct cgroup *cgrp, int cpu, bool contended)
     u64 pid = bpf_get_current_pid_tgid();
     u64 *start_hold_ts;
     struct hist_key_t key;
-    u64 delta_usec;
+    u64 delta;
 
     /* Lock hold time */
     read_array_ptr(&start_hold, &pid, start_hold_ts);
     // TODO: validate LRU lookup success
-    delta_usec = (now - *start_hold_ts) / 100; /* 0.1 usec */
+    delta = (now - *start_hold_ts) / 100; /* 0.1 usec */
 
-    increment_exp2_histogram_nosync(&cgroup_rstat_lock_hold_seconds, key, delta_usec, MAX_LATENCY_SLOT);
+    increment_exp2_histogram_nosync(&cgroup_rstat_lock_hold_seconds, key, delta, MAX_LATENCY_SLOT);
     // Should we reset timestamp?
     *start_hold_ts = 0;
 

--- a/examples/cgroup-rstat-flushing.bpf.c
+++ b/examples/cgroup-rstat-flushing.bpf.c
@@ -1,0 +1,82 @@
+/*
+ * Measure cgroup rstat (recursive stats) flushing overhead and latency.
+ *
+ * Loosely based on bpftrace script cgroup_rstat_tracepoint.bt
+ *  - https://github.com/xdp-project/xdp-project/blob/master/areas/latency/cgroup_rstat_tracepoint.bt
+ *
+ *
+ */
+
+#include <vmlinux.h>
+#include <bpf/bpf_tracing.h>
+#include "maps.bpf.h"
+
+#define MAX_CGRP_LEVELS	5
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, MAX_CGRP_LEVELS + 1);
+	__type(key, u32);
+	__type(value, u64);
+} cgroup_rstat_flush_total SEC(".maps");
+
+
+/** Measurement#1: lock rates
+ *  =========================
+ For locks, the problematic/interesting case is when the lock was contended.
+
+ Simply counting the lock+unlock is complicated by yielding the lock in the main
+ flushing loop (in cgroup_rstat_flush_locked()). The tracepoints "cpu" argument
+ will be (minus) -1 when the lock is not a yielded lock.
+
+ Concern: The lock rates will vary (a lot) and aggregating this as an average
+ will not capture spikes. Especially given Prometheus capture intervals only
+ happens every 53 seconds.
+
+ Q: will lock "type=yield" be a good idea?
+
+*/
+/* Depends on tracepoints added in kernel v6.10
+SEC("tp_btf/cgroup_rstat_locked")
+void BPF_PROG(rstat_locked, struct cgroup *cgrp, int cpu, bool contended)
+{
+
+}
+*/
+
+/** Measurement#2: latency/delay caused by flush
+ *  ============================================
+ Measure both time waiting for the lock, and time spend holding the lock.
+
+ This should be a histogram (for later latency heatmap).
+
+ */
+
+
+/** Measurement#3: flush rate
+ *  =========================
+ Simply count invocations of cgroup_rstat_flush_locked().
+
+ Concern: The flush rates will vary (a lot), e.g. then cadvisor collects stats
+ for all cgroups in the system, or when kswapd does concurrent flushing (of root
+ cgroup). Averaging this (over approx 1 minute) gives the wrong impression.
+
+ Mitigation workaround: Store counters per cgroup "level" (level=0 is root).
+ This will allow us to separate root-cgroup flushes from cadvisor walking all
+ cgroup levels.
+
+ */
+SEC("fentry/cgroup_rstat_flush_locked")
+int BPF_PROG(cgroup_rstat_flush_locked, struct cgroup *cgrp)
+{
+	u64 level_key = cgrp->level;
+
+	if (level_key > MAX_CGRP_LEVELS)
+		level_key = MAX_CGRP_LEVELS;
+
+	increment_map_nosync(&cgroup_rstat_flush_total, &level_key, 1);
+
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/examples/cgroup-rstat-flushing.bpf.c
+++ b/examples/cgroup-rstat-flushing.bpf.c
@@ -108,7 +108,7 @@ struct lock_key_t {
 };
 #define MAX_LOCK_KEY_ENTRIES 128
 
-#define MAX_ERROR_TYPES 3
+#define MAX_ERROR_TYPES 6
 enum error_types {
     ERR_UNKNOWN = 0,
     ERR_NOMEM = 1,

--- a/examples/cgroup-rstat-flushing.bpf.c
+++ b/examples/cgroup-rstat-flushing.bpf.c
@@ -126,7 +126,7 @@ int BPF_PROG(rstat_locked, struct cgroup *cgrp, int cpu, bool contended)
 SEC("fentry/cgroup_rstat_flush_locked")
 int BPF_PROG(cgroup_rstat_flush_locked, struct cgroup *cgrp)
 {
-	u64 level_key = cgrp->level;
+	u32 level_key = cgrp->level;
 
 	if (level_key > MAX_CGRP_LEVELS)
 		level_key = MAX_CGRP_LEVELS;

--- a/examples/cgroup-rstat-flushing.bpf.c
+++ b/examples/cgroup-rstat-flushing.bpf.c
@@ -45,6 +45,13 @@ struct {
 	__type(value, u64);
 } cgroup_rstat_locked_yield SEC(".maps");
 
+/* Counter for lock contended case, recorded per cgroup level */
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, MAX_CGRP_LEVELS + 1);
+	__type(key, u32);
+	__type(value, u64);
+} cgroup_rstat_lock_contended SEC(".maps");
 
 /** Measurement#1: lock rates
  *  =========================
@@ -73,6 +80,20 @@ int BPF_PROG(rstat_locked, struct cgroup *cgrp, int cpu, bool contended)
 
 	if (cpu >= 0) {
 		read_array_ptr(&cgroup_rstat_locked_yield, &key, cnt);
+		(*cnt)++;
+	}
+
+	/* What cgrp level is interesting, but I didn't manage to encode it in
+	 * above counters.  As contended case is the most interesting, have
+	 * level counter for contended.
+	 */
+	if (contended) {
+		u32 level = cgrp->level;
+
+		if (level > MAX_CGRP_LEVELS)
+			level = MAX_CGRP_LEVELS;
+
+		read_array_ptr(&cgroup_rstat_lock_contended, &level, cnt);
 		(*cnt)++;
 	}
 

--- a/examples/cgroup-rstat-flushing.bpf.c
+++ b/examples/cgroup-rstat-flushing.bpf.c
@@ -11,11 +11,11 @@
 #include <bpf/bpf_tracing.h>
 #include "maps.bpf.h"
 
-#define MAX_CGRP_LEVELS	5
+#define MAX_CGROUP_LEVELS	5
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__uint(max_entries, MAX_CGRP_LEVELS + 1);
+	__uint(max_entries, MAX_CGROUP_LEVELS + 1);
 	__type(key, u32);
 	__type(value, u64);
 } cgroup_rstat_flush_total SEC(".maps");
@@ -48,7 +48,7 @@ struct {
 /* Counter for lock contended case, recorded per cgroup level */
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__uint(max_entries, MAX_CGRP_LEVELS + 1);
+	__uint(max_entries, MAX_CGROUP_LEVELS + 1);
 	__type(key, u32);
 	__type(value, u64);
 } cgroup_rstat_lock_contended SEC(".maps");
@@ -90,8 +90,8 @@ int BPF_PROG(rstat_locked, struct cgroup *cgrp, int cpu, bool contended)
 	if (contended) {
 		u32 level = cgrp->level;
 
-		if (level > MAX_CGRP_LEVELS)
-			level = MAX_CGRP_LEVELS;
+		if (level > MAX_CGROUP_LEVELS)
+			level = MAX_CGROUP_LEVELS;
 
 		read_array_ptr(&cgroup_rstat_lock_contended, &level, cnt);
 		(*cnt)++;
@@ -128,8 +128,8 @@ int BPF_PROG(cgroup_rstat_flush_locked, struct cgroup *cgrp)
 {
 	u32 level_key = cgrp->level;
 
-	if (level_key > MAX_CGRP_LEVELS)
-		level_key = MAX_CGRP_LEVELS;
+	if (level_key > MAX_CGROUP_LEVELS)
+		level_key = MAX_CGROUP_LEVELS;
 
 	increment_map_nosync(&cgroup_rstat_flush_total, &level_key, 1);
 

--- a/examples/cgroup-rstat-flushing.bpf.c
+++ b/examples/cgroup-rstat-flushing.bpf.c
@@ -59,10 +59,7 @@ struct {
  will not capture spikes. Especially given Prometheus capture intervals only
  happens every 53 seconds.
 
- Q: will lock "type=yield" be a good idea?
-
 */
-
 SEC("tp_btf/cgroup_rstat_locked")
 int BPF_PROG(rstat_locked, struct cgroup *cgrp, int cpu, bool contended)
 {

--- a/examples/cgroup-rstat-flushing.bpf.c
+++ b/examples/cgroup-rstat-flushing.bpf.c
@@ -73,15 +73,11 @@ SEC("tp_btf/cgroup_rstat_locked")
 int BPF_PROG(rstat_locked, struct cgroup *cgrp, int cpu, bool contended)
 {
 	u32 key = contended;
-	u64 *cnt;
 
-	read_array_ptr(&cgroup_rstat_locked_total, &key, cnt);
-	(*cnt)++;
+	increment_map_nosync(&cgroup_rstat_locked_total, &key, 1);
 
-	if (cpu >= 0) {
-		read_array_ptr(&cgroup_rstat_locked_yield, &key, cnt);
-		(*cnt)++;
-	}
+	if (cpu >= 0)
+		increment_map_nosync(&cgroup_rstat_locked_yield, &key, 1);
 
 	/* What cgroup level is interesting, but I didn't manage to encode it
 	 * in above counters.  As contended case is the most interesting, have
@@ -93,8 +89,7 @@ int BPF_PROG(rstat_locked, struct cgroup *cgrp, int cpu, bool contended)
 		if (level > MAX_CGROUP_LEVELS)
 			level = MAX_CGROUP_LEVELS;
 
-		read_array_ptr(&cgroup_rstat_lock_contended, &level, cnt);
-		(*cnt)++;
+		increment_map_nosync(&cgroup_rstat_lock_contended, &level, 1);
 	}
 
 	return 0;

--- a/examples/cgroup-rstat-flushing.yaml
+++ b/examples/cgroup-rstat-flushing.yaml
@@ -45,3 +45,14 @@ metrics:
           size: 4
           decoders:
             - name: uint
+    - name: cgroup_rstat_flush_latency_seconds
+      help: Latency histogram for flush time
+      bucket_type: exp2
+      bucket_min: 0
+      bucket_max: 24
+      bucket_multiplier: 0.0000001 # 0.1 microseconds to seconds
+      labels:
+        - name: bucket
+          size: 4
+          decoders:
+            - name: uint

--- a/examples/cgroup-rstat-flushing.yaml
+++ b/examples/cgroup-rstat-flushing.yaml
@@ -8,27 +8,17 @@ metrics:
           decoders:
             - name: uint
     - name: cgroup_rstat_locked_total
-      help: Times rstat lock was obtainted plus contended state and cgroup level
+      help: Times rstat lock was obtainted with state for cgroup level, contended and yield
       labels:
         - name: contended
           size: 1
           decoders: # contended boolean converted to 0 and 1
             - name: uint
-        - name: level
+        - name: yield
           size: 1
-          decoders:
+          decoders: # was this a yielded lock case
             - name: uint
-    - name: cgroup_rstat_locked_yield
-      help: Number of times rstat lock was obtainted again after yield and contended state
-      labels:
-        - name: contended
-          size: 4
-          decoders: # contended boolean converted to 0 and 1
-            - name: uint
-    - name: cgroup_rstat_lock_contended
-      help: Lock contention counters per cgroup level
-      labels:
         - name: level
-          size: 4
+          size: 2
           decoders:
             - name: uint

--- a/examples/cgroup-rstat-flushing.yaml
+++ b/examples/cgroup-rstat-flushing.yaml
@@ -22,3 +22,15 @@ metrics:
           size: 2
           decoders:
             - name: uint
+  histograms:
+    - name: cgroup_rstat_lock_wait_seconds
+      help: Latency histogram for lock contention associated wait time to obtain lock
+      bucket_type: exp2
+      bucket_min: 0
+      bucket_max: 21
+      bucket_multiplier: 0.000001 # microseconds to seconds
+      labels:
+        - name: bucket
+          size: 4
+          decoders:
+            - name: uint

--- a/examples/cgroup-rstat-flushing.yaml
+++ b/examples/cgroup-rstat-flushing.yaml
@@ -93,7 +93,11 @@ metrics:
       bucket_max: 24
       bucket_multiplier: 0.0000001 # 0.1 microseconds to seconds
       labels:
+        - name: level
+          size: 2
+          decoders:
+            - name: uint
         - name: bucket
-          size: 4
+          size: 2
           decoders:
             - name: uint

--- a/examples/cgroup-rstat-flushing.yaml
+++ b/examples/cgroup-rstat-flushing.yaml
@@ -46,6 +46,21 @@ metrics:
           size: 4
           decoders:
             - name: uint
+    - name: cgroup_rstat_map_errors_total
+      help: Map related errors
+      labels:
+        - name: type
+          size: 4
+          decoders:
+            - name: uint
+            - name: static_map
+              static_map:
+                0: unknown
+                1: no_memory
+                2: busy
+                3: already_exists
+                4: no_elem
+                5: timestamp_zero
   histograms:
     - name: cgroup_rstat_lock_wait_seconds
       help: Latency histogram for lock contention associated wait time to obtain lock

--- a/examples/cgroup-rstat-flushing.yaml
+++ b/examples/cgroup-rstat-flushing.yaml
@@ -7,7 +7,7 @@ metrics:
           size: 4
           decoders:
             - name: uint
-    - name: cgroup_rstat_locked_state
+    - name: cgroup_rstat_locked_total
       help: Total number of times rstat lock was obtainted and contended state
       labels:
         - name: contended

--- a/examples/cgroup-rstat-flushing.yaml
+++ b/examples/cgroup-rstat-flushing.yaml
@@ -7,25 +7,12 @@ metrics:
           size: 4
           decoders:
             - name: uint
-# spans: // would work, but it seems related to ringbuf
   counters:
-    - name: cgroup_rstat_locked_total
-      help: Total number of times cgroup rstat lock was obtained
+    - name: cgroup_rstat_locked_state
+      help: Number of times rstat lock was obtainted and contended state
       labels:
-        - name: normal
-          size: 8
-          decoders:
-            - name: uint
-        - name: normal_contended
-          size: 8
-          decoders:
-            - name: uint
-        - name: yield
-          size: 8
-          decoders:
-            - name: uint
-        - name: yield_contended
-          size: 8
-          decoders:
+        - name: contended
+          size: 4
+          decoders: # contended boolean converted to 0 and 1
             - name: uint
 

--- a/examples/cgroup-rstat-flushing.yaml
+++ b/examples/cgroup-rstat-flushing.yaml
@@ -22,8 +22,8 @@ metrics:
           size: 2
           decoders:
             - name: uint
-    - name: cgroup_rstat_flush_seconds_sum
-      help: Sum amount of time spent for flushes per cgroup
+    - name: cgroup_rstat_flush_nanoseconds_sum
+      help: Sum amount of time (in nanoseconds) spent for flushes per cgroup
       labels:
         - name: cgroup
           size: 8
@@ -34,8 +34,8 @@ metrics:
           size: 4
           decoders:
             - name: uint
-    - name: cgroup_rstat_flush_seconds_count
-      help: Number of flush calls related to cgroup_rstat_flush_seconds_sum
+    - name: cgroup_rstat_flush_nanoseconds_count
+      help: Number of flush calls related to cgroup_rstat_flush_nanoseconds_sum
       labels:
         - name: cgroup
           size: 8

--- a/examples/cgroup-rstat-flushing.yaml
+++ b/examples/cgroup-rstat-flushing.yaml
@@ -22,6 +22,30 @@ metrics:
           size: 2
           decoders:
             - name: uint
+    - name: cgroup_rstat_flush_seconds_sum
+      help: Sum amount of time spent for flushes per cgroup
+      labels:
+        - name: cgroup
+          size: 8
+          decoders:
+            - name: uint
+            - name: cgroup
+        - name: level
+          size: 4
+          decoders:
+            - name: uint
+    - name: cgroup_rstat_flush_seconds_count
+      help: Number of flush calls related to cgroup_rstat_flush_seconds_sum
+      labels:
+        - name: cgroup
+          size: 8
+          decoders:
+            - name: uint
+            - name: cgroup
+        - name: level
+          size: 4
+          decoders:
+            - name: uint
   histograms:
     - name: cgroup_rstat_lock_wait_seconds
       help: Latency histogram for lock contention associated wait time to obtain lock

--- a/examples/cgroup-rstat-flushing.yaml
+++ b/examples/cgroup-rstat-flushing.yaml
@@ -27,8 +27,8 @@ metrics:
       help: Latency histogram for lock contention associated wait time to obtain lock
       bucket_type: exp2
       bucket_min: 0
-      bucket_max: 21
-      bucket_multiplier: 0.000001 # microseconds to seconds
+      bucket_max: 24
+      bucket_multiplier: 0.0000001 # 0.1 microseconds to seconds
       labels:
         - name: bucket
           size: 4
@@ -38,8 +38,8 @@ metrics:
       help: Latency histogram for lock hold time
       bucket_type: exp2
       bucket_min: 0
-      bucket_max: 21
-      bucket_multiplier: 0.000001 # microseconds to seconds
+      bucket_max: 24
+      bucket_multiplier: 0.0000001 # 0.1 microseconds to seconds
       labels:
         - name: bucket
           size: 4

--- a/examples/cgroup-rstat-flushing.yaml
+++ b/examples/cgroup-rstat-flushing.yaml
@@ -22,30 +22,32 @@ metrics:
           size: 2
           decoders:
             - name: uint
-    - name: cgroup_rstat_flush_nanoseconds_sum
-      help: Sum amount of time (in nanoseconds) spent for flushes per cgroup
-      labels:
-        - name: cgroup
-          size: 8
-          decoders:
-            - name: uint
-            - name: cgroup
-        - name: level
-          size: 4
-          decoders:
-            - name: uint
-    - name: cgroup_rstat_flush_nanoseconds_count
-      help: Number of flush calls related to cgroup_rstat_flush_nanoseconds_sum
-      labels:
-        - name: cgroup
-          size: 8
-          decoders:
-            - name: uint
-            - name: cgroup
-        - name: level
-          size: 4
-          decoders:
-            - name: uint
+# --- See: CONFIG_TRACK_PER_CGROUP_FLUSH
+#    - name: cgroup_rstat_flush_nanoseconds_sum
+#      help: Sum amount of time (in nanoseconds) spent for flushes per cgroup
+#      labels:
+#        - name: cgroup
+#          size: 8
+#          decoders:
+#            - name: uint
+#            - name: cgroup
+#        - name: level
+#          size: 4
+#          decoders:
+#            - name: uint
+#    - name: cgroup_rstat_flush_nanoseconds_count
+#      help: Number of flush calls related to cgroup_rstat_flush_nanoseconds_sum
+#      labels:
+#        - name: cgroup
+#          size: 8
+#          decoders:
+#            - name: uint
+#            - name: cgroup
+#        - name: level
+#          size: 4
+#          decoders:
+#            - name: uint
+# ---
     - name: cgroup_rstat_map_errors_total
       help: Map related errors
       labels:

--- a/examples/cgroup-rstat-flushing.yaml
+++ b/examples/cgroup-rstat-flushing.yaml
@@ -1,0 +1,9 @@
+metrics:
+  counters:
+    - name: cgroup_rstat_flush_total
+      help: Total number of times cgroup rstat were flushed (recorded per level)
+      labels:
+        - name: level
+          size: 4
+          decoders:
+            - name: uint

--- a/examples/cgroup-rstat-flushing.yaml
+++ b/examples/cgroup-rstat-flushing.yaml
@@ -7,7 +7,6 @@ metrics:
           size: 4
           decoders:
             - name: uint
-  counters:
     - name: cgroup_rstat_locked_state
       help: Total number of times rstat lock was obtainted and contended state
       labels:
@@ -15,7 +14,6 @@ metrics:
           size: 4
           decoders: # contended boolean converted to 0 and 1
             - name: uint
-  counters:
     - name: cgroup_rstat_locked_yield
       help: Number of times rstat lock was obtainted again after yield and contended state
       labels:

--- a/examples/cgroup-rstat-flushing.yaml
+++ b/examples/cgroup-rstat-flushing.yaml
@@ -34,3 +34,14 @@ metrics:
           size: 4
           decoders:
             - name: uint
+    - name: cgroup_rstat_lock_hold_seconds
+      help: Latency histogram for lock hold time
+      bucket_type: exp2
+      bucket_min: 0
+      bucket_max: 21
+      bucket_multiplier: 0.000001 # microseconds to seconds
+      labels:
+        - name: bucket
+          size: 4
+          decoders:
+            - name: uint

--- a/examples/cgroup-rstat-flushing.yaml
+++ b/examples/cgroup-rstat-flushing.yaml
@@ -21,4 +21,11 @@ metrics:
           size: 4
           decoders: # contended boolean converted to 0 and 1
             - name: uint
+    - name: cgroup_rstat_lock_contended
+      help: Lock contention counters per cgroup level
+      labels:
+        - name: level
+          size: 4
+          decoders:
+            - name: uint
 

--- a/examples/cgroup-rstat-flushing.yaml
+++ b/examples/cgroup-rstat-flushing.yaml
@@ -8,11 +8,15 @@ metrics:
           decoders:
             - name: uint
     - name: cgroup_rstat_locked_total
-      help: Total number of times rstat lock was obtainted and contended state
+      help: Times rstat lock was obtainted plus contended state and cgroup level
       labels:
         - name: contended
-          size: 4
+          size: 1
           decoders: # contended boolean converted to 0 and 1
+            - name: uint
+        - name: level
+          size: 1
+          decoders:
             - name: uint
     - name: cgroup_rstat_locked_yield
       help: Number of times rstat lock was obtainted again after yield and contended state

--- a/examples/cgroup-rstat-flushing.yaml
+++ b/examples/cgroup-rstat-flushing.yaml
@@ -7,3 +7,25 @@ metrics:
           size: 4
           decoders:
             - name: uint
+# spans: // would work, but it seems related to ringbuf
+  counters:
+    - name: cgroup_rstat_locked_total
+      help: Total number of times cgroup rstat lock was obtained
+      labels:
+        - name: normal
+          size: 8
+          decoders:
+            - name: uint
+        - name: normal_contended
+          size: 8
+          decoders:
+            - name: uint
+        - name: yield
+          size: 8
+          decoders:
+            - name: uint
+        - name: yield_contended
+          size: 8
+          decoders:
+            - name: uint
+

--- a/examples/cgroup-rstat-flushing.yaml
+++ b/examples/cgroup-rstat-flushing.yaml
@@ -9,7 +9,15 @@ metrics:
             - name: uint
   counters:
     - name: cgroup_rstat_locked_state
-      help: Number of times rstat lock was obtainted and contended state
+      help: Total number of times rstat lock was obtainted and contended state
+      labels:
+        - name: contended
+          size: 4
+          decoders: # contended boolean converted to 0 and 1
+            - name: uint
+  counters:
+    - name: cgroup_rstat_locked_yield
+      help: Number of times rstat lock was obtainted again after yield and contended state
       labels:
         - name: contended
           size: 4

--- a/examples/cgroup-rstat-flushing.yaml
+++ b/examples/cgroup-rstat-flushing.yaml
@@ -28,4 +28,3 @@ metrics:
           size: 4
           decoders:
             - name: uint
-


### PR DESCRIPTION
This PR implements example cgroup-rstat-flushing

- For analyzing cgroup rstat flushing behavior and lock contention issue observed in production

Thanks to for @bobrik for reviewing as I need to learn how to use ebpf_exporter

- For other to learn, I've kept some commits that show mistakes and followup commits that fixes these
