### PR TITLE
Bypass Netlify firewall for ebpf.io

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,4 +1,14 @@
 {
+    "httpHeaders": [
+        {
+            "urls": [
+                "https://"
+            ],
+            "headers": {
+                "user-agent": "pls let me in"
+            }
+        }
+    ],
     "ignorePatterns": [
         {
             "pattern": "http://localhost:16686/"


### PR DESCRIPTION
They do not want to let link checker through out of the box:

```
$ curl -s -H "user-agent: link-check/5.3.0" -I https://ebpf.io/what-is-ebpf/ | head -n1
HTTP/2 403
```