### PR TITLE
Ignore empty labels when aggregate values

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -713,6 +713,10 @@ func aggregateMapValues(values []metricValue) []aggregatedMetricValue {
 	mapping := map[string]*aggregatedMetricValue{}
 
 	for _, value := range values {
+		// labels can be empty if they are filtered away by decoders
+		if len(value.labels) == 0 {
+			continue
+		}
 		key := strings.Join(value.labels, "|")
 
 		if existing, ok := mapping[key]; !ok {

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -43,3 +43,33 @@ func TestAggregatedMetricValues(t *testing.T) {
 		t.Errorf("expected after aggregation: %#v, got: %#v", expected, aggregated)
 	}
 }
+
+func TestAggregatedMetricValuesEmptyLabels(t *testing.T) {
+	// labels can be empty if we skipped a label, for example with regexp
+	values := []metricValue{
+		{
+			labels: []string{},
+			value:  8,
+		},
+		{
+			labels: []string{"foo"},
+			value:  2,
+		},
+		{
+			labels: []string{"foo"},
+			value:  4,
+		},
+	}
+
+	aggregated := aggregateMapValues(values)
+	expected := []aggregatedMetricValue{
+		{
+			labels: []string{"foo"},
+			value:  6,
+		},
+	}
+
+	if !reflect.DeepEqual(aggregated, expected) {
+		t.Errorf("expected after aggregation: %#v, got: %#v", expected, aggregated)
+	}
+}


### PR DESCRIPTION
Decoder such as regexp can produce empty labels. We should ignore them, otherwise we panic when trying to walk the labels for histogram.

```
  panic: runtime error: slice bounds out of range [:-1]

  goroutine 136 [running]:
  github.com/cloudflare/ebpf_exporter/v2/exporter.(*Exporter).collectHistograms(0xc00028e0c0, 0xc000f9c7e0)
          /cfsetup_build/prometheus-ebpf-exporter/tmp/build/cloudflare-ebpf_exporter-ef5b914/exporter/exporter.go:516 +0xaae
  github.com/cloudflare/ebpf_exporter/v2/exporter.(*Exporter).Collect(0xc00028e0c0, 0xc000f9c7e0)
          /cfsetup_build/prometheus-ebpf-exporter/tmp/build/cloudflare-ebpf_exporter-ef5b914/exporter/exporter.go:460 +0x353
  github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
          /home/builder/go/pkg/mod/github.com/prometheus/client_golang@v1.19.1/prometheus/registry.go:455 +0x105
  created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather in goroutine 179
          /home/builder/go/pkg/mod/github.com/prometheus/client_golang@v1.19.1/prometheus/registry.go:547 +0xbab
```