### PR TITLE
Account for ErrSkipLabelSet when reading map values

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -567,12 +567,15 @@ func (e *Exporter) mapValues(module *libbpfgo.Module, name string, labels []conf
 
 	_, percpu := percpuMapTypes[m.Type()]
 
+	retainedMetricValues := []metricValue{}
+
 	for i, mv := range metricValues {
 		raw := mv.raw
 
 		// If there are no labels, assume a single key of uint32(0)
 		if len(labels) == 0 && bytes.Equal(mv.raw, []byte{0x0, 0x0, 0x0, 0x0}) {
 			metricValues[i].labels = []string{}
+			retainedMetricValues = append(retainedMetricValues, metricValues[i])
 			continue
 		}
 
@@ -590,9 +593,11 @@ func (e *Exporter) mapValues(module *libbpfgo.Module, name string, labels []conf
 
 			return nil, err
 		}
+
+		retainedMetricValues = append(retainedMetricValues, metricValues[i])
 	}
 
-	return metricValues, nil
+	return retainedMetricValues, nil
 }
 
 func (e *Exporter) exportMaps() (map[string]map[string][]metricValue, error) {


### PR DESCRIPTION
The panic it addresses:

```
goroutine 98 [running]:
github.com/prometheus/client_golang/prometheus.MustNewConstMetric(...)
	/home/ivan/go/pkg/mod/github.com/prometheus/client_golang@v1.20.3/prometheus/value.go:129
github.com/cloudflare/ebpf_exporter/v2/exporter.(*Exporter).collectCounters(0x40000fa0c0, 0x4000258af0)
	/home/ivan/projects/ebpf_exporter/exporter/exporter.go:483 +0x350
github.com/cloudflare/ebpf_exporter/v2/exporter.(*Exporter).Collect(0x40000fa0c0, 0x4000258af0)
	/home/ivan/projects/ebpf_exporter/exporter/exporter.go:459 +0x294
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
	/home/ivan/go/pkg/mod/github.com/prometheus/client_golang@v1.20.3/prometheus/registry.go:456 +0xd8
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather in goroutine 13
	/home/ivan/go/pkg/mod/github.com/prometheus/client_golang@v1.20.3/prometheus/registry.go:548 +0x94c
```