### PR TITLE
Bump minimum go version to v1.22

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,6 +7,7 @@ linters:
     - err113
     - execinquery # deprecated
     - exhaustruct
+    - exportloopref # deprecated
     - funlen
     - gci
     - gochecknoglobals

--- a/cgroup/monitor_test.go
+++ b/cgroup/monitor_test.go
@@ -86,7 +86,7 @@ func testMonitor(t *testing.T, m monitor, path, preExistingPath string) {
 	}
 
 	// Check addition one by one
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		dir := fmt.Sprintf("%s/lol-%d", path, i)
 
 		err = os.Mkdir(dir, 0755)
@@ -109,8 +109,8 @@ func testMonitor(t *testing.T, m monitor, path, preExistingPath string) {
 	}
 
 	// Check burst addition
-	for i := 20; i < 40; i++ {
-		dir := fmt.Sprintf("%s/lol-%d", path, i)
+	for i := range 20 {
+		dir := fmt.Sprintf("%s/lol-%d", path, 20+i)
 
 		err = os.Mkdir(dir, 0755)
 		if err != nil {
@@ -122,8 +122,8 @@ func testMonitor(t *testing.T, m monitor, path, preExistingPath string) {
 	time.Sleep(sleepDuration)
 
 	// Continue checking burst addition
-	for i := 20; i < 40; i++ {
-		dir := fmt.Sprintf("%s/lol-%d", path, i)
+	for i := range 20 {
+		dir := fmt.Sprintf("%s/lol-%d", path, 20+i)
 
 		id, err := inode(dir)
 		if err != nil {

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -219,7 +219,7 @@ func TestDecoderSetConcurrency(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(count)
 
-	for i := 0; i < count; i++ {
+	for range count {
 		go func() {
 			defer wg.Done()
 

--- a/decoder/string.go
+++ b/decoder/string.go
@@ -15,7 +15,7 @@ func (s *String) Decode(in []byte, _ config.Decoder) ([]byte, error) {
 // clen returns position of the fist null byte in a byte slice or byte slice
 // length if there is no null byte in the slice
 func clen(n []byte) int {
-	for i := 0; i < len(n); i++ {
+	for i := range n {
 		if n[i] == 0 {
 			return i
 		}

--- a/exporter/histogram.go
+++ b/exporter/histogram.go
@@ -102,7 +102,7 @@ func transformHistogramFixed(buckets map[float64]uint64, histogram config.Histog
 
 	transformed = make(map[float64]uint64, size)
 
-	for i := 0; i < len(histogram.BucketKeys); i++ {
+	for i := range len(histogram.BucketKeys) {
 		key := histogram.BucketKeys[i]
 
 		// Prometheus expects cumulative buckets with bucket being

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudflare/ebpf_exporter/v2
 
-go 1.21
+go 1.22
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
It's necessary for an opentelemetry dependency bump, so might as well.