### PR TITLE
Downgrade markdown-links-check to fix build failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ lint:
 
 .PHONY: markdown-link-check
 markdown-link-check:
-	docker run --rm -v $(shell pwd):/tmp/check:ro -w /tmp/check --entrypoint /bin/sh ghcr.io/tcort/markdown-link-check:stable -c 'markdown-link-check --config .markdown-link-check.json $$(find . -name \*.md | grep -v ^\./libbpf)'
+	docker run --rm -v $(shell pwd):/tmp/check:ro -w /tmp/check --entrypoint /bin/sh ghcr.io/tcort/markdown-link-check:3.12.2 -c 'markdown-link-check --config .markdown-link-check.json $$(find . -name \*.md | grep -v ^\./libbpf)'
 
 .PHONY: jsonschema
 jsonschema:


### PR DESCRIPTION
See: https://github.com/tcort/markdown-link-check/pull/372