### PR TITLE
Remove redaundant check in maps.bpf.h

### DIFF
--- a/examples/maps.bpf.h
+++ b/examples/maps.bpf.h
@@ -53,10 +53,6 @@ static inline int increment_map_nosync(void *map, void *key, u64 increment)
 #define _increment_ex2_histogram(map, key, increment, max_bucket, increment_fn)                                        \
     key.bucket = log2l(increment);                                                                                     \
                                                                                                                        \
-    if (key.bucket > max_bucket) {                                                                                     \
-        key.bucket = max_bucket;                                                                                       \
-    }                                                                                                                  \
-                                                                                                                       \
     _increment_histogram(map, key, increment, max_bucket, increment_fn);
 
 #define increment_exp2_histogram(map, key, increment, max_bucket)                                                      \


### PR DESCRIPTION
Remove the `max_bucket` check from `_increment_ex2_histogram`, the check is also done in `_increment_histogram`