### PR TITLE
cgroup_id_map: change example for CGRP_STORAGE to not use GET_F_CREATE

### DIFF
--- a/examples/cgroup_id_map_cgrp_storage.bpf.c
+++ b/examples/cgroup_id_map_cgrp_storage.bpf.c
@@ -29,7 +29,7 @@ int BPF_PROG(sched_migrate_task, struct task_struct *task, int dest_cpu)
 {
     u64 *ok;
     struct cgroup *cgrp = task->cgroups->dfl_cgrp;
-    ok = bpf_cgrp_storage_get(&cgroup_id_map_cgrp_storage, cgrp, 0, BPF_LOCAL_STORAGE_GET_F_CREATE);
+    ok = bpf_cgrp_storage_get(&cgroup_id_map_cgrp_storage, cgrp, 0, 0);
     if (!ok) {
         return 1;
     }


### PR DESCRIPTION
BPF_LOCAL_STORAGE_GET_F_CREATE will create a zero entry if it does not find our cgroup in the CGRP_STORAGE. THis is unnecessary work as the entry should only be written by ebpf_exporter for cgroups that we are interested in, so we should not set the flag.