### PR TITLE
Add an example of setting tag and propagate it with kernel tracing

### DIFF
--- a/examples/sock-trace.bpf.c
+++ b/examples/sock-trace.bpf.c
@@ -59,9 +59,13 @@ struct {
 } traced_socket_cookies SEC(".maps");
 
 SEC("usdt/./tracing/demos/sock/demo:ebpf_exporter:sock_set_parent_span")
-int BPF_USDT(sock_set_parent_span, u64 socket_cookie, u64 trace_id_hi, u64 trace_id_lo, u64 span_id)
+int BPF_USDT(sock_set_parent_span, u64 socket_cookie, u64 trace_id_hi, u64 trace_id_lo, u64 span_id,
+             u64 example_userspace_tag)
 {
-    struct span_parent_t parent = { .trace_id_hi = trace_id_hi, .trace_id_lo = trace_id_lo, .span_id = span_id };
+    struct span_parent_t parent = { .trace_id_hi = trace_id_hi,
+                                    .trace_id_lo = trace_id_lo,
+                                    .span_id = span_id,
+                                    .example_userspace_tag = example_userspace_tag };
 
     bpf_map_update_elem(&traced_socket_cookies, &socket_cookie, &parent, BPF_ANY);
 

--- a/examples/sock-trace.yaml
+++ b/examples/sock-trace.yaml
@@ -11,6 +11,10 @@ tracing:
           size: 8
           decoders:
             - name: hex
+        - name: example_userspace_tag
+          size: 8
+          decoders:
+            - name: uint
         - name: span_id
           size: 8
           decoders:
@@ -39,6 +43,10 @@ tracing:
           size: 8
           decoders:
             - name: hex
+        - name: example_userspace_tag
+          size: 8
+          decoders:
+            - name: uint
         - name: span_id
           size: 8
           decoders:
@@ -63,6 +71,10 @@ tracing:
           size: 8
           decoders:
             - name: hex
+        - name: example_userspace_tag
+          size: 8
+          decoders:
+            - name: uint
         - name: span_id
           size: 8
           decoders:
@@ -91,6 +103,10 @@ tracing:
           size: 8
           decoders:
             - name: hex
+        - name: example_userspace_tag
+          size: 8
+          decoders:
+            - name: uint
         - name: span_id
           size: 8
           decoders:

--- a/examples/tracing.bpf.h
+++ b/examples/tracing.bpf.h
@@ -2,6 +2,7 @@ struct span_parent_t {
     u64 trace_id_hi;
     u64 trace_id_lo;
     u64 span_id;
+    u64 example_userspace_tag;
 };
 
 struct span_base_t {

--- a/tracing/demos/sock/stitch.go
+++ b/tracing/demos/sock/stitch.go
@@ -4,9 +4,9 @@ package main
 #include <stdint.h>
 #include <sys/sdt.h>
 
-void sock_set_parent_span(uint64_t socket_cookie, uint64_t trace_id_hi, uint64_t trace_id_lo, uint64_t span_id)
+void sock_set_parent_span(uint64_t socket_cookie, uint64_t trace_id_hi, uint64_t trace_id_lo, uint64_t span_id, uint64_t example_userspace_tag)
 {
-	DTRACE_PROBE4(ebpf_exporter, sock_set_parent_span, socket_cookie, trace_id_hi, trace_id_lo, span_id);
+	DTRACE_PROBE5(ebpf_exporter, sock_set_parent_span, socket_cookie, trace_id_hi, trace_id_lo, span_id, example_userspace_tag);
 }
 */
 import "C"
@@ -29,5 +29,6 @@ func sockSentParentSpan(fd uintptr, span trace.Span) {
 		C.uint64_t(traceIDHi),
 		C.uint64_t(traceIDLo),
 		C.uint64_t(spanID),
+		C.uint64_t(666),
 	)
 }


### PR DESCRIPTION
This adds an example of tag propagation within kernel context. This can be used to set additional contexts for kernel tracing, or general tracing overall.