### PR TITLE
Fix unix-socket-backlog on kernel v6.16 and newer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,12 @@ CLANG_FORMAT_FILES = ${wildcard examples/*.c examples/*.h benchmark/probes/*.c b
 
 # * cachestat-pre-kernel-5.16 fails to attach in newer kernels (see code)
 # * llcstat requires real hardware to attach perf events, which is not present in ci
-CONFIGS_TO_IGNORE_IN_CHECK := cachestat-pre-kernel-5.16 llcstat
 # * cgroup-rstat-flushing depend on kernel v6.10, which is not yet on CI system
-CONFIGS_TO_IGNORE_IN_CHECK += cgroup-rstat-flushing
+CONFIGS_TO_IGNORE_IN_CHECK := cachestat-pre-kernel-5.16 llcstat cgroup-rstat-flushing
+ifeq (aarch64,$(shell uname -m))
+# * unix-socket-backlog depend on kernel v6.16, and aarch64 agent is older
+CONFIGS_TO_IGNORE_IN_CHECK += unix-socket-backlog
+endif
 CONFIGS_TO_CHECK := $(filter-out $(CONFIGS_TO_IGNORE_IN_CHECK), ${patsubst examples/%.yaml, %, ${wildcard examples/*.yaml}})
 
 CGO_LDFLAGS_DYNAMIC = -l bpf

--- a/examples/unix-socket-backlog.bpf.c
+++ b/examples/unix-socket-backlog.bpf.c
@@ -44,7 +44,8 @@ static int do_count(enum unix_addr addr, u64 backlog)
 }
 
 SEC("fexit/unix_find_other")
-int BPF_PROG(unix_find_other, struct net *net, struct sockaddr_un *sunaddr, int addr_len, int type, struct sock *other)
+int BPF_PROG(unix_find_other, struct net *net, struct sockaddr_un *sunaddr, int addr_len, int type, int flags,
+             struct sock *other)
 {
     // Make sure to use clang-15, otherwise you might see:
     //   libbpf: failed to find BTF for extern 'memcmp': -2


### PR DESCRIPTION
See: https://github.com/torvalds/linux/commit/a9194f88782afa1386641451a6c76beaa60485a0