### PR TITLE
Allow loading of local module symbols

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -367,11 +368,14 @@ func (e *Exporter) populateKaddrs() error {
 	}
 
 	defer fd.Close()
+	return e.populateKaddrsFrom(fd)
+}
 
-	s := bufio.NewScanner(fd)
+func (e *Exporter) populateKaddrsFrom(r io.Reader) error {
+	s := bufio.NewScanner(r)
 	for s.Scan() {
-		parts := strings.Split(s.Text(), " ")
-		if len(parts) != 3 {
+		parts := strings.Fields(s.Text())
+		if len(parts) < 3 {
 			continue
 		}
 

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -384,7 +384,10 @@ func (e *Exporter) populateKaddrsFrom(r io.Reader) error {
 			return fmt.Errorf("error parsing addr %q from line %q: %w", parts[0], s.Text(), err)
 		}
 
-		e.kaddrs[parts[2]] = addr
+		name := parts[2]
+		if _, ok := e.kaddrs[name]; !ok {
+			e.kaddrs[name] = addr
+		}
 	}
 
 	return s.Err()

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -9,7 +9,9 @@ import (
 
 func TestPopulateKaddrsFrom(t *testing.T) {
 	e := &Exporter{kaddrs: map[string]uint64{}}
-	kallsyms := strings.NewReader("ffffffff81000000 T builtin_symbol\nffffffffc0001000 t module_symbol\t[example]\n")
+	kallsyms := strings.NewReader("ffffffff81000000 T builtin_symbol\n" +
+		"ffffffffc0001000 t module_symbol\t[example]\n" +
+		"ffffffffc0002000 t builtin_symbol\t[example]\n")
 
 	if err := e.populateKaddrsFrom(kallsyms); err != nil {
 		t.Fatal(err)

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -3,8 +3,26 @@ package exporter
 import (
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 )
+
+func TestPopulateKaddrsFrom(t *testing.T) {
+	e := &Exporter{kaddrs: map[string]uint64{}}
+	kallsyms := strings.NewReader("ffffffff81000000 T builtin_symbol\nffffffffc0001000 t module_symbol\t[example]\n")
+
+	if err := e.populateKaddrsFrom(kallsyms); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]uint64{
+		"builtin_symbol": 0xffffffff81000000,
+		"module_symbol":  0xffffffffc0001000,
+	}
+	if !reflect.DeepEqual(e.kaddrs, expected) {
+		t.Errorf("expected kaddrs %#v, got %#v", expected, e.kaddrs)
+	}
+}
 
 func TestAggregatedMetricValues(t *testing.T) {
 	values := []metricValue{


### PR DESCRIPTION
This expands kallsyms scanning to allow symbols that are from modules. In addition, if we have duplicate symbols prefer the first-loaded name. This also adds unit tests as needed.